### PR TITLE
Fix server output config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ Inside of your Astro project, you'll see the following folders and files:
 └── package.json
 ```
 
-## Para desplegarlo en producción (ej: Vercel, Netlify, VPS), asegúrate de:
-# usar output: 'server' en astro.config.mjs,
+## Para desplegarlo en producción (ej: Vercel, Netlify, VPS), asegúrate de usar `output: 'server'` en `astro.config.mjs`:
+
+```js
+export default defineConfig({
+  output: 'server',
+  // resto de tu configuración...
+});
+```
 
 ## 🧞 editar
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,10 +2,10 @@
 import { defineConfig } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
-output: "server";
 
 // https://astro.build/config
 export default defineConfig({
+  output: 'server',
   site: 'http://localhost:4321',
   vite: {
     plugins: [tailwindcss()]


### PR DESCRIPTION
## Summary
- fix config by moving `output: 'server'` inside `defineConfig`
- document updated config in the README

## Testing
- `pnpm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e0352068483229cc563abfbf5afe1