### PR TITLE
Add env-configurable DB test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,23 @@ Inside of your Astro project, you'll see the following folders and files:
 | `pnpm preview`         | Preview your build locally, before deploying     |
 | `pnpm astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `pnpm astro -- --help` | Get help using the Astro CLI                     |
+
+## Test de conexión a la base de datos
+
+El proyecto incluye `test-db.js` para comprobar la conexión con MySQL. Puedes
+ejecutarlo definiendo variables de entorno para el host, el usuario y la
+contraseña. Cada una cuenta con un valor por defecto:
+
+- `DB_HOST` (por defecto `db.clawn.cat`)
+- `DB_USER` (por defecto `conexiones`)
+- `DB_PASSWORD` (por defecto `1234`)
+- `DB_PORT` (opcional, por defecto `3306`)
+- `DB_NAME` (opcional, por defecto `streamplus`)
+
+Para lanzar la prueba:
+
+```bash
+DB_HOST=tu-host DB_USER=tu-usuario DB_PASSWORD=tu-clave node test-db.js
+```
+
+Si la consulta no devuelve resultados se mostrará un error.

--- a/test-db.js
+++ b/test-db.js
@@ -1,12 +1,13 @@
 // test-db.js
 import mysql from 'mysql2/promise';
+import assert from 'node:assert';
 
 const dbConfig = {
-  host: 'db.clawn.cat',     // Cambia si usas un host diferente
-  port: 3306,            // Puerto por defecto
-  user: 'conexiones',          // Usuario de tu DB
-  password: '1234',          // Contraseña de tu DB
-  database: 'streamplus' // Nombre de tu base de datos
+  host: process.env.DB_HOST || 'db.clawn.cat',
+  port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306,
+  user: process.env.DB_USER || 'conexiones',
+  password: process.env.DB_PASSWORD || '1234',
+  database: process.env.DB_NAME || 'streamplus'
 };
 
 async function testConnection() {
@@ -15,6 +16,7 @@ async function testConnection() {
     console.log('✅ Conexión a la base de datos exitosa');
 
     const [rows] = await connection.execute('SELECT NOW() AS fecha;');
+    assert(rows.length > 0, 'La consulta no devolvió resultados');
     console.log('🕓 Respuesta desde la DB:', rows[0]);
 
     await connection.end();


### PR DESCRIPTION
## Summary
- let test-db.js read host, user and password from env vars
- assert that the query returns results
- document how to run the DB test and set env variables

## Testing
- `node --check test-db.js`


------
https://chatgpt.com/codex/tasks/task_e_685e0352dcd48322be4b6544c62bb9fe