### PR TITLE
Improve header dropdown behavior

### DIFF
--- a/src/pages/header.astro
+++ b/src/pages/header.astro
@@ -37,41 +37,32 @@ import Layout from '../layouts/Layout.astro';
         <button class="hover:text-purple-400">favorito</button>
 
         <!-- Contenedor del avatar con dropdown -->
-        <button
+        <div
           id="menu-user"
           class="w-12 h-12 rounded-full overflow-hidden border-2 border-purple-500 cursor-pointer relative"
           tabindex="0"
           aria-haspopup="true"
           aria-expanded="false"
         >
-          <img src="./avatar.jpeg" alt="User" class="w-full h-full object-cover" />
+          <img id="user-avatar" src="/avatar.svg" alt="User" class="w-full h-full object-cover" />
 
           <!-- Menú desplegable oculto inicialmente con "hidden" -->
-          <button
+          <div
             id="dropdown-menu"
-            class="absolute right-0 mt-45 w-40 bg-black text-white rounded shadow-lg hidden z-50"
+            class="absolute right-0 mt-2 w-40 bg-black text-white rounded shadow-lg hidden z-50"
           >
-            <a
-              href="/admin"
-              class="block px-4 py-2 hover:bg-purple-700"
-              tabindex="0" >Panel</a>
-            <a
-              href="#"
-              class="block px-4 py-2 hover:bg-purple-700"
-              tabindex="0"
-            >Configuración</a>
-            <a
-              href="#"
-              class="block px-4 py-2 hover:bg-purple-700"
-              tabindex="0"
-            >Perfil</a>
-            <a
-              href="#"
-              class="block px-4 py-2 hover:bg-purple-700"
-              tabindex="0"
-            >Cerrar sesión</a>
-          </button>
-        </button>
+            <div id="logged-out-menu">
+              <a href="/login" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Logearse</a>
+              <a href="/register" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Registrarse</a>
+            </div>
+            <div id="logged-in-menu" class="hidden">
+              <a href="/admin" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Panel</a>
+              <a href="#" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Configuración</a>
+              <a href="#" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Perfil</a>
+              <button id="logout-btn" class="w-full text-left px-4 py-2 hover:bg-purple-700" tabindex="0">Cerrar sesión</button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -93,6 +84,10 @@ import Layout from '../layouts/Layout.astro';
       const mobileMenu = document.getElementById('mobile-menu');
       const menuUser = document.getElementById('menu-user');
       const dropdownMenu = document.getElementById('dropdown-menu');
+      const avatarImg = document.getElementById('user-avatar');
+      const loggedOutMenu = document.getElementById('logged-out-menu');
+      const loggedInMenu = document.getElementById('logged-in-menu');
+      const logoutBtn = document.getElementById('logout-btn');
 
       if (!toggleBtn || !mobileMenu || !menuUser || !dropdownMenu) {
         console.error('Elementos del menú no encontrados');
@@ -111,6 +106,22 @@ import Layout from '../layouts/Layout.astro';
         if (!menuUser.contains(event.target) && !dropdownMenu.contains(event.target)) {
           dropdownMenu.classList.add('hidden');
         }
+      });
+
+      const user = JSON.parse(localStorage.getItem('user') || 'null');
+      if (user) {
+        if (user.avatar) avatarImg.src = user.avatar;
+        loggedOutMenu.classList.add('hidden');
+        loggedInMenu.classList.remove('hidden');
+      } else {
+        avatarImg.src = '/avatar.svg';
+        loggedOutMenu.classList.remove('hidden');
+        loggedInMenu.classList.add('hidden');
+      }
+
+      logoutBtn?.addEventListener('click', () => {
+        localStorage.removeItem('user');
+        window.location.reload();
       });
     });
 </script>


### PR DESCRIPTION
## Summary
- tweak dropdown menu to show correct profile image
- default menu shows login/register links when user is not logged
- add script to switch menu options depending on `localStorage` user data
- fix dropdown positioning

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e06c6bd9483228139ed563057c165