### PR TITLE
Add missing login and view pages

### DIFF
--- a/src/pages/header.astro
+++ b/src/pages/header.astro
@@ -37,41 +37,32 @@ import Layout from '../layouts/Layout.astro';
         <button class="hover:text-purple-400">favorito</button>
 
         <!-- Contenedor del avatar con dropdown -->
-        <button
+        <div
           id="menu-user"
           class="w-12 h-12 rounded-full overflow-hidden border-2 border-purple-500 cursor-pointer relative"
           tabindex="0"
           aria-haspopup="true"
           aria-expanded="false"
         >
-          <img src="./avatar.jpeg" alt="User" class="w-full h-full object-cover" />
+          <img id="user-avatar" src="/avatar.svg" alt="User" class="w-full h-full object-cover" />
 
           <!-- Menú desplegable oculto inicialmente con "hidden" -->
-          <button
+          <div
             id="dropdown-menu"
-            class="absolute right-0 mt-45 w-40 bg-black text-white rounded shadow-lg hidden z-50"
+            class="absolute right-0 mt-2 w-40 bg-black text-white rounded shadow-lg hidden z-50"
           >
-            <a
-              href="/admin"
-              class="block px-4 py-2 hover:bg-purple-700"
-              tabindex="0" >Panel</a>
-            <a
-              href="#"
-              class="block px-4 py-2 hover:bg-purple-700"
-              tabindex="0"
-            >Configuración</a>
-            <a
-              href="#"
-              class="block px-4 py-2 hover:bg-purple-700"
-              tabindex="0"
-            >Perfil</a>
-            <a
-              href="#"
-              class="block px-4 py-2 hover:bg-purple-700"
-              tabindex="0"
-            >Cerrar sesión</a>
-          </button>
-        </button>
+            <div id="logged-out-menu">
+              <a href="/login" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Logearse</a>
+              <a href="/register" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Registrarse</a>
+            </div>
+            <div id="logged-in-menu" class="hidden">
+              <a href="/admin" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Panel</a>
+              <a href="#" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Configuración</a>
+              <a href="#" class="block px-4 py-2 hover:bg-purple-700" tabindex="0">Perfil</a>
+              <button id="logout-btn" class="w-full text-left px-4 py-2 hover:bg-purple-700" tabindex="0">Cerrar sesión</button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -93,6 +84,10 @@ import Layout from '../layouts/Layout.astro';
       const mobileMenu = document.getElementById('mobile-menu');
       const menuUser = document.getElementById('menu-user');
       const dropdownMenu = document.getElementById('dropdown-menu');
+      const avatarImg = document.getElementById('user-avatar');
+      const loggedOutMenu = document.getElementById('logged-out-menu');
+      const loggedInMenu = document.getElementById('logged-in-menu');
+      const logoutBtn = document.getElementById('logout-btn');
 
       if (!toggleBtn || !mobileMenu || !menuUser || !dropdownMenu) {
         console.error('Elementos del menú no encontrados');
@@ -111,6 +106,22 @@ import Layout from '../layouts/Layout.astro';
         if (!menuUser.contains(event.target) && !dropdownMenu.contains(event.target)) {
           dropdownMenu.classList.add('hidden');
         }
+      });
+
+      const user = JSON.parse(localStorage.getItem('user') || 'null');
+      if (user) {
+        if (user.avatar) avatarImg.src = user.avatar;
+        loggedOutMenu.classList.add('hidden');
+        loggedInMenu.classList.remove('hidden');
+      } else {
+        avatarImg.src = '/avatar.svg';
+        loggedOutMenu.classList.remove('hidden');
+        loggedInMenu.classList.add('hidden');
+      }
+
+      logoutBtn?.addEventListener('click', () => {
+        localStorage.removeItem('user');
+        window.location.reload();
       });
     });
 </script>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,0 +1,30 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout>
+  <section class="px-4 py-8 max-w-md mx-auto">
+    <h1 class="text-white text-2xl font-bold mb-6">Iniciar sesión</h1>
+    <form id="login-form" class="grid gap-4">
+      <input type="text" name="usuario" placeholder="Usuario" required class="p-2 rounded" />
+      <input type="url" name="avatar" placeholder="URL del avatar (opcional)" class="p-2 rounded" />
+      <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white px-5 py-2 rounded font-semibold">Entrar</button>
+    </form>
+  </section>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const form = document.getElementById('login-form');
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const data = new FormData(form);
+        const user = {
+          name: data.get('usuario'),
+          avatar: data.get('avatar') || '/avatar.svg'
+        };
+        localStorage.setItem('user', JSON.stringify(user));
+        window.location.href = '/';
+      });
+    });
+  </script>
+</Layout>

--- a/src/pages/register.astro
+++ b/src/pages/register.astro
@@ -1,0 +1,31 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout>
+  <section class="px-4 py-8 max-w-md mx-auto">
+    <h1 class="text-white text-2xl font-bold mb-6">Registrarse</h1>
+    <form id="register-form" class="grid gap-4">
+      <input type="text" name="usuario" placeholder="Usuario" required class="p-2 rounded" />
+      <input type="email" name="correo" placeholder="Correo" required class="p-2 rounded" />
+      <input type="url" name="avatar" placeholder="URL del avatar (opcional)" class="p-2 rounded" />
+      <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white px-5 py-2 rounded font-semibold">Crear cuenta</button>
+    </form>
+  </section>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const form = document.getElementById('register-form');
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const data = new FormData(form);
+        const user = {
+          name: data.get('usuario'),
+          avatar: data.get('avatar') || '/avatar.svg'
+        };
+        localStorage.setItem('user', JSON.stringify(user));
+        window.location.href = '/';
+      });
+    });
+  </script>
+</Layout>

--- a/src/pages/ver/[id].astro
+++ b/src/pages/ver/[id].astro
@@ -1,0 +1,10 @@
+---
+import Layout from '../../layouts/Layout.astro';
+---
+
+<Layout>
+  <section class="px-4 py-8">
+    <h1 class="text-white text-3xl font-bold mb-4">Serie {Astro.params.id}</h1>
+    <p class="text-gray-300">Esta página aún está en construcción.</p>
+  </section>
+</Layout>


### PR DESCRIPTION
## Summary
- create `/login` page with simple localStorage login logic
- create `/register` page to mimic user registration
- add basic `/ver/[id]` page as placeholder
- maintain previous header dropdown logic

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e06c6bd9483228139ed563057c165