### PR TITLE
Add Kitsu series creation API

### DIFF
--- a/src/pages/admin/serie/nueva.astro
+++ b/src/pages/admin/serie/nueva.astro
@@ -27,11 +27,18 @@ export const prerender = false;
     </div>
 
     <input name="titulo" type="text" placeholder="Título" required class="w-full p-2 bg-gray-700 rounded" />
+    <input name="slug" type="text" placeholder="Slug" class="w-full p-2 bg-gray-700 rounded" />
     <textarea name="descripcion" placeholder="Descripción" class="w-full p-2 bg-gray-700 rounded"></textarea>
     <input name="banner" type="url" placeholder="URL Banner" class="w-full p-2 bg-gray-700 rounded" />
     <input name="icon" type="url" placeholder="URL Icono" class="w-full p-2 bg-gray-700 rounded" />
     <input name="fecha_estreno" type="date" class="w-full p-2 bg-gray-700 rounded" />
     <input name="genero" type="text" placeholder="Género" class="w-full p-2 bg-gray-700 rounded" />
+    <input name="clasificacion_edad" type="text" placeholder="Clasificación de edad" class="w-full p-2 bg-gray-700 rounded" />
+    <select name="translation" class="w-full p-2 bg-gray-700 rounded">
+      <option value="subbed">Subtitulado</option>
+      <option value="dubbed">Doblado</option>
+      <option value="raw">Raw</option>
+    </select>
     <select name="carrucel_1" class="w-full p-2 bg-gray-700 rounded">
       <option value="1">Mostrar en Carrusel</option>
       <option value="0">No Mostrar</option>
@@ -39,7 +46,9 @@ export const prerender = false;
     <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Crear Serie</button>
   </form>
 
-  <script>
+  <script type="module">
+    const API_KEY = import.meta.env.PUBLIC_KITSU_API_KEY ||
+      'IrvECAcgihh9VeAR8BH3F_RmpFrjU0y-gZdw1ZA8JWI';
     const statusEl = document.getElementById('kitsu-status');
     const queryInput = document.getElementById('kitsu-query');
     const form = document.getElementById('serie-form');
@@ -68,11 +77,13 @@ export const prerender = false;
         }
 
         form.titulo.value = data.titulo || '';
+        form.slug.value = data.slug || '';
         form.descripcion.value = data.descripcion || '';
         form.banner.value = data.banner || '';
         form.icon.value = data.icon || '';
         form.fecha_estreno.value = data.fecha_estreno || '';
         form.genero.value = data.genero || '';
+        form.clasificacion_edad.value = data.clasificacion_edad || '';
 
         statusEl.textContent = 'Datos cargados desde Kitsu.';
       } catch (err) {
@@ -84,6 +95,7 @@ export const prerender = false;
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       const data = Object.fromEntries(new FormData(e.target));
+      data.key = API_KEY;
       const res = await fetch('/api/series', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/pages/api/series/index.ts
+++ b/src/pages/api/series/index.ts
@@ -1,0 +1,155 @@
+import type { APIRoute } from 'astro';
+import db from '../../../lib/db';
+import fs from 'fs/promises';
+import path from 'path';
+
+const DEFAULT_BANNER = 'http://181.74.89.24:5696/ClawnVid/img/anime/newicons/no_wp.jpg';
+const API_KEY = process.env.KITSU_API_KEY || 'IrvECAcgihh9VeAR8BH3F_RmpFrjU0y-gZdw1ZA8JWI';
+const KITSU_DIR = path.join(process.cwd(), 'public', 'kitsuImages');
+
+function sanitizeSlug(raw: string, translation?: string) {
+  const clean = (raw || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .substring(0, 100);
+
+  const suffix = translation && ['raw', 'dubbed'].includes(translation) ? `-${translation}` : '';
+  return (clean || 'serie') + suffix;
+}
+
+function getExtension(url: string) {
+  try {
+    const pathname = new URL(url).pathname;
+    const parts = pathname.split('.');
+    if (parts.length > 1) return parts.pop() as string;
+  } catch {
+    // ignore
+  }
+  return 'jpg';
+}
+
+async function saveRemoteImage(url: string, filename: string) {
+  const ext = getExtension(url);
+  const filePath = path.join(KITSU_DIR, `${filename}.${ext}`);
+
+  await fs.mkdir(KITSU_DIR, { recursive: true });
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`No se pudo descargar la imagen: ${url}`);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await fs.writeFile(filePath, buffer);
+
+  return `/kitsuImages/${filename}.${ext}`;
+}
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  let payload: Record<string, any>;
+  try {
+    payload = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'JSON inválido' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const {
+    key,
+    id,
+    titulo,
+    descripcion,
+    cover,
+    banner,
+    fecha_estreno,
+    genero,
+    clasificacion_edad,
+    translation,
+    slug,
+    icon,
+    idioma,
+    popularidad,
+    carrucel_1,
+    destacado_reciente,
+  } = payload;
+
+  if (key !== API_KEY) {
+    return new Response(JSON.stringify({ error: 'API key inválida' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!titulo || !descripcion) {
+    return new Response(JSON.stringify({ error: 'Faltan título o descripción' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!cover && !icon) {
+    return new Response(JSON.stringify({ error: 'Falta la imagen de portada (cover/icon)' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const translationLower = (translation || idioma || 'subbed').toLowerCase();
+  if (!['subbed', 'dubbed', 'raw'].includes(translationLower)) {
+    return new Response(JSON.stringify({ error: 'translation debe ser subbed, dubbed o raw' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const normalizedSlug = sanitizeSlug(slug || titulo, translationLower);
+  const coverUrl = cover || icon;
+  const bannerUrl = banner?.trim() ? banner : DEFAULT_BANNER;
+
+  try {
+    const [coverPublicPath, bannerPublicPath] = await Promise.all([
+      saveRemoteImage(coverUrl, `cover_${id || normalizedSlug}`),
+      saveRemoteImage(bannerUrl, `banner_${id || normalizedSlug}`),
+    ]);
+
+    const [result] = await db.execute(
+      `INSERT INTO series (slug, titulo, descripcion, banner, icon, fecha_estreno, genero, clasificacion_edad, idioma, popularidad, carrucel_1, destacado_reciente)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)` as string,
+      [
+        normalizedSlug,
+        titulo,
+        descripcion,
+        bannerPublicPath,
+        coverPublicPath,
+        fecha_estreno || null,
+        genero || null,
+        clasificacion_edad || null,
+        translationLower,
+        popularidad ?? 0,
+        carrucel_1 ?? 0,
+        destacado_reciente ?? 0,
+      ]
+    );
+
+    const insertId = (result as any)?.insertId;
+    return new Response(
+      JSON.stringify({
+        message: 'success',
+        id: insertId,
+        slug: normalizedSlug,
+        banner: bannerPublicPath,
+        icon: coverPublicPath,
+      }),
+      { status: 201, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Error creando serie desde Kitsu', error);
+    return new Response(
+      JSON.stringify({ error: 'Error interno al crear la serie' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+};


### PR DESCRIPTION
## Summary
- add POST /api/series endpoint that validates an API key, downloads cover/banner assets, and stores a new series record
- extend the admin "nueva serie" form to capture slug, clasificación, idioma and send the API key to the new endpoint

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b850f58e88331bb885699b2613017)