### PR TITLE
Fix API key injection in admin forms

### DIFF
--- a/src/pages/admin/api/index.astro
+++ b/src/pages/admin/api/index.astro
@@ -1,6 +1,8 @@
 ---
 import AdminLayout from '../_layout.astro';
 export const prerender = false;
+const API_KEY = import.meta.env.PUBLIC_KITSU_API_KEY ||
+  'IrvECAcgihh9VeAR8BH3F_RmpFrjU0y-gZdw1ZA8JWI';
 ---
 
 <AdminLayout>
@@ -32,7 +34,7 @@ export const prerender = false;
     </div>
   </section>
 
-  <form id="api-form" class="bg-gray-800 p-6 rounded-lg space-y-4">
+  <form id="api-form" class="bg-gray-800 p-6 rounded-lg space-y-4" data-api-key={API_KEY}>
     <h2 class="text-white text-xl font-semibold">Crear serie</h2>
     <input name="titulo" type="text" placeholder="Título" required class="w-full p-2 bg-gray-700 rounded" />
     <input name="slug" type="text" placeholder="Slug" class="w-full p-2 bg-gray-700 rounded" />
@@ -60,8 +62,7 @@ export const prerender = false;
   </form>
 
   <script type="module">
-    const API_KEY = import.meta.env.PUBLIC_KITSU_API_KEY ||
-      'IrvECAcgihh9VeAR8BH3F_RmpFrjU0y-gZdw1ZA8JWI';
+    const API_KEY = document.getElementById('api-form').dataset.apiKey;
     const statusEl = document.getElementById('kitsu-status');
     const queryInput = document.getElementById('kitsu-query');
     const form = document.getElementById('api-form');

--- a/src/pages/admin/serie/nueva.astro
+++ b/src/pages/admin/serie/nueva.astro
@@ -1,11 +1,17 @@
 ---
 import AdminLayout from '../_layout.astro';
 export const prerender = false;
+const API_KEY = import.meta.env.PUBLIC_KITSU_API_KEY ||
+  'IrvECAcgihh9VeAR8BH3F_RmpFrjU0y-gZdw1ZA8JWI';
 ---
 
 <AdminLayout>
   <h1 class="text-white text-3xl font-bold mb-6">Agregar Nueva Serie</h1>
-  <form id="serie-form" class="bg-gray-800 p-6 rounded-lg space-y-4">
+  <form
+    id="serie-form"
+    class="bg-gray-800 p-6 rounded-lg space-y-4"
+    data-api-key={API_KEY}
+  >
     <input name="titulo" type="text" placeholder="Título" required class="w-full p-2 bg-gray-700 rounded" />
     <input name="slug" type="text" placeholder="Slug" class="w-full p-2 bg-gray-700 rounded" />
     <textarea name="descripcion" placeholder="Descripción" class="w-full p-2 bg-gray-700 rounded" required></textarea>
@@ -32,14 +38,12 @@ export const prerender = false;
   </form>
 
   <script type="module">
-    const API_KEY = import.meta.env.PUBLIC_KITSU_API_KEY ||
-      'IrvECAcgihh9VeAR8BH3F_RmpFrjU0y-gZdw1ZA8JWI';
     const form = document.getElementById('serie-form');
 
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       const data = Object.fromEntries(new FormData(e.target));
-      data.key = API_KEY;
+      data.key = form.dataset.apiKey;
       data.destacado_reciente = data.destacado_reciente ? 1 : 0;
       data.popularidad = data.popularidad ? Number(data.popularidad) : 0;
       const res = await fetch('/api/series', {


### PR DESCRIPTION
## Summary
- move PUBLIC_KITSU_API_KEY lookup to server-side frontmatter on admin forms
- pass the key to client scripts via data attributes instead of import.meta
- avoid runtime crashes when the env object is unavailable in the browser

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b8c2ded648331a0ba1dff3fe95a9f)