### PR TITLE
Improve admin UI styling

### DIFF
--- a/src/pages/admin/_layout.astro
+++ b/src/pages/admin/_layout.astro
@@ -4,27 +4,45 @@ export const prerender = false;
 ---
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		<title>ClawnVid ADMIN</title>
-	</head>
-<Layout>
-  <div class="flex">
-    <!-- Sidebar -->
-    <aside class="w-56 bg-gray-900 text-purple-400 min-h-screen fixed pt-16">
-      <nav>
-        <a href="/admin" class="block px-4 py-2 hover:bg-gray-800">Gestionar Series</a>
-        <a href="/admin/api" class="block px-4 py-2 hover:bg-gray-800">Integración API</a>
-        <a href="/admin/usuarios" class="block px-4 py-2 hover:bg-gray-800">Gestionar Usuarios</a>
-        <a href="/admin/suscripciones" class="block px-4 py-2 hover:bg-gray-800">Gestionar Suscripciones</a>
-        <a href="/logout" class="block px-4 py-2 hover:bg-gray-800 text-red-500">Logout</a>
-      </nav>
-    </aside>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>ClawnVid ADMIN</title>
+  </head>
+  <Layout>
+    <div class="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-purple-950 text-gray-100">
+      <div class="flex">
+        <!-- Sidebar -->
+        <aside class="w-64 bg-gray-950/80 border-r border-purple-800/40 backdrop-blur-xl text-purple-200 min-h-screen fixed pt-16 shadow-2xl">
+          <div class="px-6 py-4 border-b border-purple-800/40">
+            <p class="text-sm uppercase tracking-[0.2em] text-purple-400">Panel</p>
+            <p class="text-xl font-semibold text-white">Administración</p>
+          </div>
+          <nav class="py-4 flex flex-col gap-1">
+            <a href="/admin" class="mx-4 px-4 py-2 rounded-lg transition-colors duration-200 text-sm font-medium text-purple-100 hover:bg-purple-800/30 hover:text-white">📺 Gestionar Series</a>
+            <a href="/admin/api" class="mx-4 px-4 py-2 rounded-lg transition-colors duration-200 text-sm font-medium text-purple-100 hover:bg-purple-800/30 hover:text-white">🔗 Integración API</a>
+            <a href="/admin/usuarios" class="mx-4 px-4 py-2 rounded-lg transition-colors duration-200 text-sm font-medium text-purple-100 hover:bg-purple-800/30 hover:text-white">👤 Gestionar Usuarios</a>
+            <a href="/admin/suscripciones" class="mx-4 px-4 py-2 rounded-lg transition-colors duration-200 text-sm font-medium text-purple-100 hover:bg-purple-800/30 hover:text-white">💳 Gestionar Suscripciones</a>
+            <a href="/logout" class="mx-4 px-4 py-2 rounded-lg transition-colors duration-200 text-sm font-medium text-red-300 hover:text-white hover:bg-red-500/20">🚪 Cerrar sesión</a>
+          </nav>
+        </aside>
 
-    <!-- Main content -->
-    <main class="flex-1 ml-56 pt-16 px-8">
-      <slot />
-    </main>
-  </div>
-</Layout>
+        <!-- Main content -->
+        <main class="flex-1 ml-64 min-h-screen pt-16">
+          <header class="sticky top-0 z-10 backdrop-blur bg-gray-900/70 border-b border-purple-800/40 px-8 py-4 flex items-center justify-between shadow-lg">
+            <div>
+              <p class="text-xs uppercase tracking-[0.3em] text-purple-300">ClawnVid</p>
+              <p class="text-lg font-semibold text-white">Centro de control</p>
+            </div>
+            <span class="px-3 py-1 rounded-full bg-purple-600/30 text-purple-100 border border-purple-500/40 text-xs font-semibold">Modo administrador</span>
+          </header>
+          <div class="p-8">
+            <div class="rounded-2xl border border-purple-800/40 bg-gray-900/80 shadow-2xl p-6 backdrop-blur-xl">
+              <slot />
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  </Layout>
+</html>

--- a/src/pages/admin/api/index.astro
+++ b/src/pages/admin/api/index.astro
@@ -6,102 +6,139 @@ const API_KEY = import.meta.env.PUBLIC_KITSU_API_KEY ||
 ---
 
 <AdminLayout>
-  <h1 class="text-white text-3xl font-bold mb-6">Integración API</h1>
-  <p class="text-gray-300 mb-4">
-    Consulta datos de Kitsu y crea series con los campos requeridos por la base de datos.
-  </p>
+  <div class="flex flex-col gap-6">
+    <div class="flex items-start justify-between flex-wrap gap-4">
+      <div>
+        <p class="text-sm text-purple-200/80">Automatiza tu catálogo</p>
+        <h1 class="text-white text-3xl font-extrabold">Integración API</h1>
+        <p class="text-gray-300 mt-1 max-w-2xl">Consulta datos de Kitsu, visualiza un resumen previo y genera series listas para la base de datos.</p>
+      </div>
+      <div class="px-4 py-2 rounded-lg bg-purple-900/40 border border-purple-700/50 text-sm text-purple-100 shadow-lg">
+        API key activa: <span class="font-semibold">{API_KEY.slice(0, 6)}•••</span>
+      </div>
+    </div>
 
-  <section class="bg-gray-800 p-6 rounded-lg space-y-4 mb-6">
-    <h2 class="text-white text-xl font-semibold">Buscar en Kitsu</h2>
-    <div class="space-y-2">
-      <label class="block text-gray-300 text-sm font-semibold">Slug o texto</label>
-      <div class="flex gap-2">
-        <input
-          id="kitsu-query"
-          type="text"
-          placeholder="Slug o título"
-          class="w-full p-2 bg-gray-700 rounded"
-        />
+    <section class="bg-gray-900/60 backdrop-blur border border-purple-800/40 rounded-2xl p-6 shadow-2xl shadow-purple-950/40">
+      <div class="flex items-center justify-between gap-4 mb-4">
+        <div>
+          <h2 class="text-white text-xl font-semibold">Buscar en Kitsu</h2>
+          <p class="text-gray-400 text-sm">Usa un slug o título para precargar la información base.</p>
+        </div>
+        <span class="inline-flex items-center justify-center px-3 py-1 rounded-full text-xs font-semibold border bg-green-900/40 text-green-100 border-green-700/50">Tiempo real</span>
+      </div>
+      <div class="space-y-2">
+        <label class="block text-gray-300 text-sm font-semibold">Slug o texto</label>
+        <div class="flex flex-col md:flex-row gap-2">
+          <input
+            id="kitsu-query"
+            type="text"
+            placeholder="Ej. naruto-shippuden"
+            class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500"
+          />
+          <button
+            id="kitsu-button"
+            type="button"
+            class="inline-flex justify-center items-center gap-2 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-500 hover:to-blue-500 text-white px-4 py-3 rounded-lg shadow-lg shadow-purple-900/40"
+          >
+            🔍 Buscar
+          </button>
+        </div>
+        <p id="kitsu-status" class="text-sm text-gray-300"></p>
+      </div>
+    </section>
+
+    <form id="api-form" class="bg-gray-900/60 backdrop-blur border border-purple-800/40 rounded-2xl p-6 shadow-2xl shadow-purple-950/40 space-y-4" data-api-key={API_KEY}>
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h2 class="text-white text-xl font-semibold">Crear serie</h2>
+          <p class="text-gray-400 text-sm">Completa o ajusta los campos antes de enviar.</p>
+        </div>
+        <div class="flex items-center gap-2 text-xs text-gray-300">
+          <span class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span> Auto guardado manual
+        </div>
+      </div>
+      <div class="grid md:grid-cols-2 gap-4">
+        <input name="titulo" type="text" placeholder="Título" required class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100" />
+        <input name="slug" type="text" placeholder="Slug" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100" />
+        <input name="banner" type="url" placeholder="URL Banner" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100" />
+        <input name="icon" type="url" placeholder="URL Icono (portada)" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100" required />
+        <input name="fecha_estreno" type="date" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100" />
+        <input name="genero" type="text" placeholder="Género" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100" />
+        <input name="clasificacion_edad" type="text" placeholder="Clasificación de edad" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100" />
+        <input name="popularidad" type="number" min="0" placeholder="Popularidad" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100" />
+      </div>
+      <textarea name="descripcion" placeholder="Descripción" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100 min-h-[120px]" required></textarea>
+      <div class="grid md:grid-cols-3 gap-4">
+        <div class="space-y-2">
+          <label class="text-sm text-gray-300">Traducción</label>
+          <select name="translation" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100">
+            <option value="subbed">Subtitulado</option>
+            <option value="dubbed">Doblado</option>
+            <option value="raw">Raw</option>
+          </select>
+        </div>
+        <div class="space-y-2">
+          <label class="text-sm text-gray-300">Carrusel</label>
+          <select name="carrucel_1" class="w-full p-3 bg-gray-800/70 border border-purple-700/40 rounded-lg focus:outline-none focus:border-purple-500 text-gray-100">
+            <option value="1">Mostrar en Carrusel</option>
+            <option value="0">No Mostrar</option>
+          </select>
+        </div>
+        <label class="flex items-center gap-2 text-gray-300 text-sm pt-6">
+          <input type="checkbox" name="destacado_reciente" value="1" class="accent-purple-600 w-4 h-4 rounded" />
+          Destacar como recién agregado
+        </label>
+      </div>
+      <div class="flex flex-wrap gap-3">
         <button
-          id="kitsu-button"
+          id="preview-button"
           type="button"
-          class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded"
+          class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold text-purple-100 bg-purple-900/40 border border-purple-700/40 hover:bg-purple-800/60 transition shadow-lg shadow-purple-900/30"
         >
-          Buscar
+          Vista previa
+        </button>
+        <button type="submit" class="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-500 text-white px-4 py-2.5 rounded-lg font-semibold shadow-lg shadow-blue-900/30">
+          Crear Serie
         </button>
       </div>
-      <p id="kitsu-status" class="text-sm text-gray-400"></p>
-    </div>
-  </section>
+    </form>
 
-  <form id="api-form" class="bg-gray-800 p-6 rounded-lg space-y-4" data-api-key={API_KEY}>
-    <h2 class="text-white text-xl font-semibold">Crear serie</h2>
-    <input name="titulo" type="text" placeholder="Título" required class="w-full p-2 bg-gray-700 rounded" />
-    <input name="slug" type="text" placeholder="Slug" class="w-full p-2 bg-gray-700 rounded" />
-    <textarea name="descripcion" placeholder="Descripción" class="w-full p-2 bg-gray-700 rounded" required></textarea>
-    <input name="banner" type="url" placeholder="URL Banner" class="w-full p-2 bg-gray-700 rounded" />
-    <input name="icon" type="url" placeholder="URL Icono (portada)" class="w-full p-2 bg-gray-700 rounded" required />
-    <input name="fecha_estreno" type="date" class="w-full p-2 bg-gray-700 rounded" />
-    <input name="genero" type="text" placeholder="Género" class="w-full p-2 bg-gray-700 rounded" />
-    <input name="clasificacion_edad" type="text" placeholder="Clasificación de edad" class="w-full p-2 bg-gray-700 rounded" />
-    <input name="popularidad" type="number" min="0" placeholder="Popularidad" class="w-full p-2 bg-gray-700 rounded" />
-    <select name="translation" class="w-full p-2 bg-gray-700 rounded">
-      <option value="subbed">Subtitulado</option>
-      <option value="dubbed">Doblado</option>
-      <option value="raw">Raw</option>
-    </select>
-    <select name="carrucel_1" class="w-full p-2 bg-gray-700 rounded">
-      <option value="1">Mostrar en Carrusel</option>
-      <option value="0">No Mostrar</option>
-    </select>
-    <label class="flex items-center gap-2 text-gray-300 text-sm">
-      <input type="checkbox" name="destacado_reciente" value="1" class="accent-purple-600" />
-      Destacar como recién agregado
-    </label>
-    <div class="flex flex-wrap gap-3">
-      <button
-        id="preview-button"
-        type="button"
-        class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded"
-      >
-        Vista previa
-      </button>
-      <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Crear Serie</button>
-    </div>
-  </form>
-
-  <section id="preview-section" class="bg-gray-800 p-6 rounded-lg space-y-4 mt-6 hidden">
-    <div class="flex items-center justify-between gap-4">
-      <h2 class="text-white text-xl font-semibold">Vista previa del envío</h2>
-      <span class="text-xs text-gray-400">No se ha guardado en la base de datos.</span>
-    </div>
-    <div class="grid md:grid-cols-2 gap-4">
-      <div class="space-y-2">
-        <p class="text-gray-300"><strong>Título:</strong> <span id="preview-title"></span></p>
-        <p class="text-gray-300"><strong>Slug:</strong> <span id="preview-slug"></span></p>
-        <p class="text-gray-300"><strong>Idioma:</strong> <span id="preview-language"></span></p>
-        <p class="text-gray-300"><strong>Género:</strong> <span id="preview-genre"></span></p>
-        <p class="text-gray-300"><strong>Estreno:</strong> <span id="preview-date"></span></p>
-        <p class="text-gray-300"><strong>Popularidad:</strong> <span id="preview-popularity"></span></p>
-        <p class="text-gray-300"><strong>Descripción:</strong></p>
-        <p class="text-gray-400" id="preview-description"></p>
-      </div>
-      <div class="space-y-2">
+    <section id="preview-section" class="bg-gray-900/60 backdrop-blur border border-purple-800/40 rounded-2xl p-6 shadow-2xl shadow-purple-950/40 space-y-4 hidden">
+      <div class="flex items-center justify-between gap-4">
         <div>
-          <p class="text-gray-300 mb-1"><strong>Banner</strong></p>
-          <div class="bg-gray-700 rounded overflow-hidden aspect-[16/6] flex items-center justify-center">
-            <img id="preview-banner" class="w-full h-full object-cover" alt="Vista previa banner" />
-          </div>
+          <h2 class="text-white text-xl font-semibold">Vista previa del envío</h2>
+          <p class="text-gray-400 text-sm">Verifica la información antes de guardarla.</p>
         </div>
-        <div>
-          <p class="text-gray-300 mb-1"><strong>Icono / Cover</strong></p>
-          <div class="bg-gray-700 rounded overflow-hidden aspect-[4/5] w-48 flex items-center justify-center">
-            <img id="preview-icon" class="w-full h-full object-cover" alt="Vista previa icono" />
+        <span class="text-xs text-gray-400">No se ha guardado en la base de datos.</span>
+      </div>
+      <div class="grid md:grid-cols-2 gap-4">
+        <div class="space-y-2">
+          <p class="text-gray-300"><strong>Título:</strong> <span id="preview-title"></span></p>
+          <p class="text-gray-300"><strong>Slug:</strong> <span id="preview-slug"></span></p>
+          <p class="text-gray-300"><strong>Idioma:</strong> <span id="preview-language"></span></p>
+          <p class="text-gray-300"><strong>Género:</strong> <span id="preview-genre"></span></p>
+          <p class="text-gray-300"><strong>Estreno:</strong> <span id="preview-date"></span></p>
+          <p class="text-gray-300"><strong>Popularidad:</strong> <span id="preview-popularity"></span></p>
+          <p class="text-gray-300"><strong>Descripción:</strong></p>
+          <p class="text-gray-400" id="preview-description"></p>
+        </div>
+        <div class="space-y-4">
+          <div>
+            <p class="text-gray-300 mb-1"><strong>Banner</strong></p>
+            <div class="bg-gray-800 rounded-xl overflow-hidden aspect-[16/6] flex items-center justify-center border border-purple-800/40">
+              <img id="preview-banner" class="w-full h-full object-cover" alt="Vista previa banner" />
+            </div>
+          </div>
+          <div>
+            <p class="text-gray-300 mb-1"><strong>Icono / Cover</strong></p>
+            <div class="bg-gray-800 rounded-xl overflow-hidden aspect-[4/5] w-48 flex items-center justify-center border border-purple-800/40">
+              <img id="preview-icon" class="w-full h-full object-cover" alt="Vista previa icono" />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+  </div>
 
   <script type="module">
     const API_KEY = document.getElementById('api-form').dataset.apiKey;

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -13,64 +13,108 @@ try {
 ---
 
 <AdminLayout>
-  <h1 class="text-white text-3xl font-bold mb-6">Gestionar Series</h1>
-  <a href="/admin/serie/nueva" class="bg-blue-500 hover:bg-blue-600 text-white px-5 py-2 rounded-md">
-    Agregar Serie
-  </a>
+  <div class="flex items-center justify-between mb-8">
+    <div>
+      <p class="text-sm text-purple-200/80">Resumen general</p>
+      <h1 class="text-white text-3xl font-extrabold">Gestionar series</h1>
+      <p class="text-gray-300 mt-1">Revisa, edita y destaca rápidamente el catálogo disponible.</p>
+    </div>
+    <a
+      href="/admin/serie/nueva"
+      class="inline-flex items-center gap-2 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-500 hover:to-blue-500 text-white px-5 py-2.5 rounded-lg shadow-lg shadow-purple-900/40 transition-all"
+    >
+      <span class="text-xl">＋</span>
+      <span class="font-semibold">Agregar serie</span>
+    </a>
+  </div>
 
-  <table class="w-full mt-6 text-white table-auto border border-gray-700">
-    <thead class="bg-gray-800">
-      <tr>
-        <th>ID</th>
-        <th>Título</th>
-        <th>Fecha Estreno</th>
-        <th>Popularidad</th>
-        <th>Carrusel</th>
-        <th>Recién</th>
-        <th>Acciones</th>
-      </tr>
-    </thead>
-    <tbody>
-      {series.map(s => (
-        <tr class="border-t border-gray-700" key={s.id}>
-          <td class="px-4 py-2">{s.id}</td>
-          <td class="px-4 py-2">{s.titulo}</td>
-          <td class="px-4 py-2">{s.fecha_estreno}</td>
-          <td class="px-4 py-2">{s.popularidad}</td>
-          <!-- Checkbox Carrusel -->
-          <td class="px-4 py-2 text-center">
-            <input
-              type="checkbox"
-              class="toggle-field"
-              data-id={s.id}
-              data-field="carrucel_1"
-              checked={s.carrucel_1 === 1}
-            />
-          </td>
-          <!-- Checkbox Recién Agregado -->
-          <td class="px-4 py-2 text-center">
-            <input
-              type="checkbox"
-              class="toggle-field"
-              data-id={s.id}
-              data-field="destacado_reciente"
-              checked={s.destacado_reciente === 1}
-            />
-          </td>
-          <td class="px-4 py-2 space-x-2">
-            <a href={`/admin/serie/${s.id}/temporadas`} class="text-blue-400 hover:underline">Temporadas</a>
-            <a href={`/admin/serie/editar/${s.id}`} class="text-blue-400 hover:underline">Editar</a>
-            <a href="#" class="text-red-500 hover:underline">Eliminar</a>
-          </td>
-        </tr>
-      ))}
-      {series.length === 0 && (
+  <div class="grid md:grid-cols-3 gap-4 mb-8">
+    <div class="bg-gray-900/60 backdrop-blur border border-purple-800/40 rounded-xl p-4 shadow-lg shadow-purple-900/40">
+      <p class="text-sm text-purple-200/80">Series totales</p>
+      <p class="text-3xl font-extrabold text-white">{series.length || '—'}</p>
+    </div>
+    <div class="bg-gray-900/60 backdrop-blur border border-purple-800/40 rounded-xl p-4 shadow-lg shadow-purple-900/40">
+      <p class="text-sm text-purple-200/80">En carrusel</p>
+      <p class="text-3xl font-extrabold text-white">{series.filter(s => s.carrucel_1 === 1).length}</p>
+    </div>
+    <div class="bg-gray-900/60 backdrop-blur border border-purple-800/40 rounded-xl p-4 shadow-lg shadow-purple-900/40">
+      <p class="text-sm text-purple-200/80">Recién agregadas</p>
+      <p class="text-3xl font-extrabold text-white">{series.filter(s => s.destacado_reciente === 1).length}</p>
+    </div>
+  </div>
+
+  <div class="overflow-x-auto rounded-xl border border-purple-800/40 bg-gray-900/60 backdrop-blur">
+    <table class="w-full text-left text-sm">
+      <thead class="bg-purple-900/40 text-purple-100 text-xs uppercase tracking-wide">
         <tr>
-          <td colSpan="7" class="text-center text-gray-400 py-4">No hay series registradas.</td>
+          <th class="px-4 py-3">ID</th>
+          <th class="px-4 py-3">Título</th>
+          <th class="px-4 py-3">Fecha Estreno</th>
+          <th class="px-4 py-3">Popularidad</th>
+          <th class="px-4 py-3 text-center">Carrusel</th>
+          <th class="px-4 py-3 text-center">Recién</th>
+          <th class="px-4 py-3">Acciones</th>
         </tr>
-      )}
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="divide-y divide-purple-800/40 text-gray-100">
+        {series.map(s => (
+          <tr class="hover:bg-purple-900/20 transition-colors" key={s.id}>
+            <td class="px-4 py-3 font-semibold text-purple-100">#{s.id}</td>
+            <td class="px-4 py-3">
+              <p class="font-semibold text-white">{s.titulo}</p>
+              <p class="text-xs text-gray-400">Slug: {s.slug || '—'}</p>
+            </td>
+            <td class="px-4 py-3">{s.fecha_estreno || '—'}</td>
+            <td class="px-4 py-3">
+              <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-blue-900/40 text-blue-100 text-xs font-semibold">
+                ⭐ {s.popularidad || 0}
+              </span>
+            </td>
+            <td class="px-4 py-3 text-center">
+              <span class={`inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs font-semibold border ${s.carrucel_1 === 1 ? 'bg-green-900/40 text-green-100 border-green-700/50' : 'bg-gray-800/60 text-gray-300 border-gray-700/60'}`}>
+                {s.carrucel_1 === 1 ? 'Visible' : 'Oculta'}
+              </span>
+              <div class="mt-2">
+                <input
+                  type="checkbox"
+                  class="toggle-field accent-purple-500"
+                  data-id={s.id}
+                  data-field="carrucel_1"
+                  checked={s.carrucel_1 === 1}
+                />
+              </div>
+            </td>
+            <td class="px-4 py-3 text-center">
+              <span class={`inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs font-semibold border ${s.destacado_reciente === 1 ? 'bg-green-900/40 text-green-100 border-green-700/50' : 'bg-gray-800/60 text-gray-300 border-gray-700/60'}`}>
+                {s.destacado_reciente === 1 ? 'Destacado' : 'Normal'}
+              </span>
+              <div class="mt-2">
+                <input
+                  type="checkbox"
+                  class="toggle-field accent-purple-500"
+                  data-id={s.id}
+                  data-field="destacado_reciente"
+                  checked={s.destacado_reciente === 1}
+                />
+              </div>
+            </td>
+            <td class="px-4 py-3">
+              <div class="flex flex-wrap gap-2">
+                <a href={`/admin/serie/${s.id}/temporadas`} class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-purple-100 bg-purple-900/40 border border-purple-700/40 hover:bg-purple-800/60 transition">Temporadas</a>
+                <a href={`/admin/serie/editar/${s.id}`} class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-purple-100 bg-purple-900/40 border border-purple-700/40 hover:bg-purple-800/60 transition">Editar</a>
+                <a href="#" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-red-200 bg-red-900/30 border border-red-700/40 hover:bg-red-800/40 transition">Eliminar</a>
+              </div>
+            </td>
+          </tr>
+        ))}
+        {series.length === 0 && (
+          <tr>
+            <td colSpan="7" class="text-center text-gray-400 py-6">No hay series registradas.</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  </div>
 </AdminLayout>
 
 <script>

--- a/src/pages/admin/suscripciones/index.astro
+++ b/src/pages/admin/suscripciones/index.astro
@@ -12,35 +12,48 @@ try {
 ---
 
 <AdminLayout>
-  <h1 class="text-white text-3xl font-bold mb-6">Gestionar Suscripciones</h1>
-  <a href="/admin/suscripciones/nueva" class="bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded text-white">
-    Agregar Suscripción
-  </a>
+  <div class="flex items-start justify-between flex-wrap gap-4 mb-6">
+    <div>
+      <p class="text-sm text-purple-200/80">Planes y monetización</p>
+      <h1 class="text-white text-3xl font-extrabold">Gestionar suscripciones</h1>
+      <p class="text-gray-300 mt-1">Edita precios, beneficios y crea nuevas ofertas.</p>
+    </div>
+    <a href="/admin/suscripciones/nueva" class="inline-flex items-center gap-2 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-500 hover:to-blue-500 px-4 py-2.5 rounded-lg text-white font-semibold shadow-lg shadow-purple-900/40">
+      ➕ Agregar suscripción
+    </a>
+  </div>
 
-  <table class="w-full mt-6 text-white table-auto border border-gray-700">
-    <thead class="bg-gray-800">
-      <tr>
-        <th>ID</th><th>Nombre</th><th>Precio</th><th>Descripción</th><th>Acciones</th>
-      </tr>
-    </thead>
-    <tbody>
-      {subs.map(s => (
-        <tr class="border-t border-gray-700" key={s.id}>
-          <td class="px-4 py-2">{s.id}</td>
-          <td class="px-4 py-2">{s.nombre}</td>
-          <td class="px-4 py-2">{Number(s.precio).toFixed(2)}</td>
-          <td class="px-4 py-2">{s.descripcion}</td>
-          <td class="px-4 py-2 space-x-2">
-            <a href={`/admin/suscripciones/editar/${s.id}`} class="text-blue-400 hover:underline">Editar</a>
-            <a href="#" class="text-red-500 hover:underline">Eliminar</a>
-          </td>
-        </tr>
-      ))}
-      {subs.length === 0 && (
+  <div class="overflow-x-auto rounded-xl border border-purple-800/40 bg-gray-900/60 backdrop-blur">
+    <table class="w-full text-left text-sm">
+      <thead class="bg-purple-900/40 text-purple-100 text-xs uppercase tracking-wide">
         <tr>
-          <td colSpan="5" class="text-center text-gray-400 py-4">No hay suscripciones.</td>
+          <th class="px-4 py-3">ID</th><th class="px-4 py-3">Nombre</th><th class="px-4 py-3">Precio</th><th class="px-4 py-3">Descripción</th><th class="px-4 py-3">Acciones</th>
         </tr>
-      )}
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="divide-y divide-purple-800/40 text-gray-100">
+        {subs.map(s => (
+          <tr class="hover:bg-purple-900/20 transition-colors" key={s.id}>
+            <td class="px-4 py-3 font-semibold text-purple-100">#{s.id}</td>
+            <td class="px-4 py-3">
+              <p class="font-semibold text-white">{s.nombre}</p>
+              <p class="text-xs text-gray-400">{s.duracion || 'Sin duración'}</p>
+            </td>
+            <td class="px-4 py-3 text-lg font-bold text-green-300">${Number(s.precio).toFixed(2)}</td>
+            <td class="px-4 py-3 text-gray-200">{s.descripcion}</td>
+            <td class="px-4 py-3">
+              <div class="flex flex-wrap gap-2">
+                <a href={`/admin/suscripciones/editar/${s.id}`} class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-purple-100 bg-purple-900/40 border border-purple-700/40 hover:bg-purple-800/60 transition">Editar</a>
+                <a href="#" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-red-200 bg-red-900/30 border border-red-700/40 hover:bg-red-800/40 transition">Eliminar</a>
+              </div>
+            </td>
+          </tr>
+        ))}
+        {subs.length === 0 && (
+          <tr>
+            <td colSpan="5" class="text-center text-gray-400 py-6">No hay suscripciones.</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  </div>
 </AdminLayout>

--- a/src/pages/admin/usuarios/index.astro
+++ b/src/pages/admin/usuarios/index.astro
@@ -12,37 +12,70 @@ try {
 }
 ---
 <AdminLayout>
-  <h1 class="text-white text-3xl font-bold mb-6">Gestionar Usuarios</h1>
-  <table class="w-full mt-6 text-white table-auto border border-gray-700">
-    <thead class="bg-gray-800">
-      <tr>
-        <th>ID</th><th>Nickname</th><th>Apodo</th><th>Suscripción</th><th>Estado</th><th>Admin</th><th>Acciones</th>
-      </tr>
-    </thead>
-    <tbody>
-      {usuarios.map(u => (
-        <tr class="border-t border-gray-700" key={u.id}>
-          <td class="px-4 py-2">{u.id}</td>
-          <td class="px-4 py-2">{u.nickname}</td>
-          <td class="px-4 py-2">{u.apodo}</td>
-          <td class="px-4 py-2">{u.suscripcion}</td>
-          <td class="px-4 py-2">{u.baneado ? 'Baneado' : 'Activo'}</td>
-          <td class="px-4 py-2">{u.es_admin ? 'Sí' : 'No'}</td>
-          <td class="px-4 py-2 space-x-2">
-            <a href={`/admin/usuarios/editar/${u.id}`} class="text-blue-400 hover:underline">Editar</a>
-            {u.es_admin
-              ? <a href="#" class="text-purple-400 hover:underline">Revocar Admin</a>
-              : <a href="#" class="text-purple-400 hover:underline">Promover Admin</a>}
-            {u.baneado
-              ? <a href="#" class="text-yellow-400 hover:underline">Desbanear</a>
-              : <a href="#" class="text-red-500 hover:underline">Banear</a>}
-            <a href="#" class="text-red-500 hover:underline">Eliminar</a>
-          </td>
+  <div class="flex items-start justify-between flex-wrap gap-4 mb-6">
+    <div>
+      <p class="text-sm text-purple-200/80">Seguridad y acceso</p>
+      <h1 class="text-white text-3xl font-extrabold">Gestionar usuarios</h1>
+      <p class="text-gray-300 mt-1">Controla roles, baneos y perfiles de la comunidad.</p>
+    </div>
+    <div class="px-4 py-2 rounded-lg bg-gray-900/60 border border-purple-800/40 text-sm text-gray-200 shadow-lg">
+      Total registrados: <span class="font-semibold">{usuarios.length || '—'}</span>
+    </div>
+  </div>
+
+  <div class="overflow-x-auto rounded-xl border border-purple-800/40 bg-gray-900/60 backdrop-blur">
+    <table class="w-full text-left text-sm">
+      <thead class="bg-purple-900/40 text-purple-100 text-xs uppercase tracking-wide">
+        <tr>
+          <th class="px-4 py-3">ID</th>
+          <th class="px-4 py-3">Nickname</th>
+          <th class="px-4 py-3">Apodo</th>
+          <th class="px-4 py-3">Suscripción</th>
+          <th class="px-4 py-3">Estado</th>
+          <th class="px-4 py-3">Admin</th>
+          <th class="px-4 py-3">Acciones</th>
         </tr>
-      ))}
-      {usuarios.length === 0 && (
-        <tr><td colSpan="7" class="text-center text-gray-400 py-4">No hay usuarios.</td></tr>
-      )}
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="divide-y divide-purple-800/40 text-gray-100">
+        {usuarios.map(u => (
+          <tr class="hover:bg-purple-900/20 transition-colors" key={u.id}>
+            <td class="px-4 py-3 font-semibold text-purple-100">#{u.id}</td>
+            <td class="px-4 py-3">
+              <p class="font-semibold text-white">{u.nickname}</p>
+              <p class="text-xs text-gray-400">{u.correo || 'Sin correo'}</p>
+            </td>
+            <td class="px-4 py-3">{u.apodo || '—'}</td>
+            <td class="px-4 py-3">
+              <span class="inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs font-semibold border bg-green-900/40 text-green-100 border-green-700/50">{u.suscripcion || 'Libre'}</span>
+            </td>
+            <td class="px-4 py-3">
+              <span class={`inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs font-semibold border ${u.baneado ? 'bg-gray-800/60 text-gray-300 border-gray-700/60' : 'bg-green-900/40 text-green-100 border-green-700/50'}`}>
+                {u.baneado ? 'Baneado' : 'Activo'}
+              </span>
+            </td>
+            <td class="px-4 py-3">
+              <span class={`inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs font-semibold border ${u.es_admin ? 'bg-green-900/40 text-green-100 border-green-700/50' : 'bg-gray-800/60 text-gray-300 border-gray-700/60'}`}>
+                {u.es_admin ? 'Administrador' : 'Usuario'}
+              </span>
+            </td>
+            <td class="px-4 py-3">
+              <div class="flex flex-wrap gap-2">
+                <a href={`/admin/usuarios/editar/${u.id}`} class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-purple-100 bg-purple-900/40 border border-purple-700/40 hover:bg-purple-800/60 transition">Editar</a>
+                {u.es_admin
+                  ? <a href="#" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-purple-100 bg-purple-900/40 border border-purple-700/40 hover:bg-purple-800/60 transition">Revocar Admin</a>
+                  : <a href="#" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-purple-100 bg-purple-900/40 border border-purple-700/40 hover:bg-purple-800/60 transition">Promover Admin</a>}
+                {u.baneado
+                  ? <a href="#" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-purple-100 bg-purple-900/40 border border-purple-700/40 hover:bg-purple-800/60 transition">Desbanear</a>
+                  : <a href="#" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-red-200 bg-red-900/30 border border-red-700/40 hover:bg-red-800/40 transition">Banear</a>}
+                <a href="#" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold text-red-200 bg-red-900/30 border border-red-700/40 hover:bg-red-800/40 transition">Eliminar</a>
+              </div>
+            </td>
+          </tr>
+        ))}
+        {usuarios.length === 0 && (
+          <tr><td colSpan="7" class="text-center text-gray-400 py-6">No hay usuarios.</td></tr>
+        )}
+      </tbody>
+    </table>
+  </div>
 </AdminLayout>


### PR DESCRIPTION
## Summary
- refresh the admin layout with gradient background, modern sidebar, and sticky header
- restyle series, users, subscriptions, and API integration views with cards, badges, and improved buttons
- enhance API creation form with clearer inputs and preview pane styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c456a2bd88331a65e2818612b282b)