### PR TITLE
Adjust header spacing and soften overlay

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,12 +10,12 @@ import "../styles/global.css";
 		<title>ClawnVid</title>
 		<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 	</head>
-	<body>
-		<Header />
-		<main>
-			<slot />
-		</main>
-	</body>
+        <body class="bg-black text-white">
+                <Header />
+                <main class="pt-16 md:pt-20">
+                        <slot />
+                </main>
+        </body>
 </html>
 
 <style>

--- a/src/pages/header.astro
+++ b/src/pages/header.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<header class="bg-black/80 backdrop-blur-md fixed top-0 w-full z-50">
+<header class="bg-black/60 supports-[backdrop-filter]:backdrop-blur-md fixed top-0 w-full z-50 border-b border-white/10 shadow-lg">
   <div class="w-full px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16">
 


### PR DESCRIPTION
## Summary
- add page padding to account for the fixed header and set a consistent background
- soften the header overlay with lighter opacity plus a subtle border and shadow

## Testing
- npm run build *(fails: npm unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c491631788331b296d32a9ce70dd7)