### PR TITLE
Add functional favorites section

### DIFF
--- a/src/pages/api/favoritos/[serieId].ts
+++ b/src/pages/api/favoritos/[serieId].ts
@@ -1,0 +1,52 @@
+import type { APIRoute } from 'astro';
+import db from '../../../lib/db';
+
+export const POST: APIRoute = async ({ params, cookies }) => {
+  const serieId = Number(params.serieId);
+  const usuarioId = Number(cookies.get('usuario_id')?.value);
+
+  if (!usuarioId) {
+    return new Response(
+      JSON.stringify({ error: 'Usuario no autenticado' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  if (!serieId) {
+    return new Response(
+      JSON.stringify({ error: 'Serie no válida' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    const [[existing]] = await db.query<{ id: number }[]>(
+      `SELECT id FROM favoritos WHERE usuario_id = ? AND serie_id = ? LIMIT 1`,
+      [usuarioId, serieId]
+    );
+
+    let favorito: boolean;
+
+    if (existing?.id) {
+      await db.query(`DELETE FROM favoritos WHERE id = ?`, [existing.id]);
+      favorito = false;
+    } else {
+      await db.query(
+        `INSERT INTO favoritos (usuario_id, serie_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE fecha_agregado = CURRENT_TIMESTAMP()`,
+        [usuarioId, serieId]
+      );
+      favorito = true;
+    }
+
+    return new Response(
+      JSON.stringify({ favorito }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Error al actualizar favorito:', error);
+    return new Response(
+      JSON.stringify({ error: 'No se pudo actualizar el favorito' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+};

--- a/src/pages/favoritos.astro
+++ b/src/pages/favoritos.astro
@@ -1,0 +1,136 @@
+---
+import { redirect } from 'astro';
+import type { RowDataPacket } from 'mysql2';
+import Layout from '../layouts/Layout.astro';
+import db from '../lib/db';
+
+export const prerender = false;
+
+interface Favorito extends RowDataPacket {
+  id: number;
+  slug: string;
+  titulo: string;
+  icon: string;
+  descripcion: string;
+  genero: string;
+  temporada_count: number;
+  episodio_count: number;
+  fecha_agregado: string;
+}
+
+const usuarioId = Astro.cookies.get('usuario_id')?.value;
+if (!usuarioId) {
+  throw redirect('/login');
+}
+
+const [favoritos] = await db.query<Favorito[]>(
+  `SELECT s.id, s.slug, s.titulo, s.icon, s.descripcion, s.genero, f.fecha_agregado,
+          (SELECT COUNT(*) FROM temporadas t WHERE t.serie_id = s.id) AS temporada_count,
+          (SELECT COUNT(*) FROM episodios e JOIN temporadas t ON e.temporada_id = t.id WHERE t.serie_id = s.id) AS episodio_count
+     FROM favoritos f
+     JOIN series s ON s.id = f.serie_id
+    WHERE f.usuario_id = ?
+    ORDER BY f.fecha_agregado DESC`,
+  [usuarioId]
+);
+---
+<Layout>
+  <section class="px-4 py-12 max-w-6xl mx-auto">
+    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      <div>
+        <p class="text-sm uppercase tracking-[0.2em] text-white/60">Tu colección</p>
+        <h1 class="text-3xl font-bold text-white">Favoritos</h1>
+        <p class="text-white/70">Series que guardaste para ver más tarde.</p>
+      </div>
+      <span class="inline-flex items-center gap-2 rounded-full bg-purple-600/30 text-purple-100 px-4 py-2 text-sm font-semibold">
+        ⭐ {favoritos.length} guardados
+      </span>
+    </div>
+
+    {favoritos.length === 0 ? (
+      <div class="mt-10 rounded-2xl border border-white/10 bg-slate-900/60 p-10 text-center">
+        <h2 class="text-xl font-semibold text-white">Todavía no tienes favoritos</h2>
+        <p class="mt-2 text-white/70">Explora el catálogo y añade tus series preferidas.</p>
+        <a href="/directorio" class="mt-6 inline-flex items-center gap-2 rounded-xl bg-purple-600 px-4 py-2 text-white shadow-lg shadow-purple-900/30 hover:bg-purple-500">
+          Ir al directorio
+        </a>
+      </div>
+    ) : (
+      <div id="favorites-grid" class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {favoritos.map(fav => (
+          <article
+            class="group relative overflow-hidden rounded-2xl border border-white/5 bg-slate-900/70 shadow-xl transition hover:-translate-y-1 hover:border-purple-500/50"
+            data-serie-card
+            data-serie-id={fav.id}
+          >
+            <div class="aspect-video overflow-hidden">
+              <img src={fav.icon} alt={fav.titulo} class="h-full w-full object-cover transition duration-500 group-hover:scale-105" />
+              <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+            </div>
+            <div class="p-4 space-y-3">
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <h3 class="text-xl font-semibold text-white">{fav.titulo}</h3>
+                  <p class="text-xs uppercase tracking-wide text-purple-200/80">{fav.genero}</p>
+                </div>
+                <button
+                  class="remove-fav inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white hover:bg-red-500/80"
+                  data-serie-id={fav.id}
+                >
+                  Quitar
+                </button>
+              </div>
+              <p class="text-sm text-white/70 line-clamp-3">{fav.descripcion}</p>
+              <div class="flex items-center gap-3 text-xs text-white/60">
+                <span class="rounded-full bg-white/10 px-2 py-1">{fav.temporada_count} Temp</span>
+                <span class="rounded-full bg-white/10 px-2 py-1">{fav.episodio_count} Epis</span>
+              </div>
+              <a href={`/serie/${fav.slug}`} class="inline-flex items-center gap-2 text-sm font-semibold text-purple-300 hover:text-white">
+                Ver detalles
+                <span aria-hidden="true">→</span>
+              </a>
+            </div>
+          </article>
+        ))}
+      </div>
+    )}
+  </section>
+</Layout>
+
+<script client:load>
+  const grid = document.getElementById('favorites-grid');
+  if (grid) {
+    grid.addEventListener('click', async (event) => {
+      const target = event.target as HTMLElement;
+      const button = target.closest('.remove-fav') as HTMLElement | null;
+      if (!button) return;
+
+      const serieId = button.dataset.serieId;
+      if (!serieId) return;
+
+      button.textContent = 'Quitando...';
+      button.setAttribute('disabled', 'true');
+
+      try {
+        const res = await fetch(`/api/favoritos/${serieId}`, { method: 'POST' });
+        if (!res.ok) throw new Error('No se pudo actualizar');
+        const card = button.closest('[data-serie-card]') as HTMLElement | null;
+        card?.remove();
+
+        if (!grid.querySelector('[data-serie-card]')) {
+          grid.outerHTML = `
+            <div class="mt-10 rounded-2xl border border-white/10 bg-slate-900/60 p-10 text-center">
+              <h2 class="text-xl font-semibold text-white">Favoritos vacíos</h2>
+              <p class="mt-2 text-white/70">Empieza a guardar series y aparecerán aquí.</p>
+              <a href="/directorio" class="mt-6 inline-flex items-center gap-2 rounded-xl bg-purple-600 px-4 py-2 text-white shadow-lg shadow-purple-900/30 hover:bg-purple-500">
+                Buscar series
+              </a>
+            </div>`;
+        }
+      } catch (error) {
+        console.error(error);
+        button.textContent = 'Error';
+      }
+    });
+  }
+</script>

--- a/src/pages/header.astro
+++ b/src/pages/header.astro
@@ -17,6 +17,7 @@ import Layout from '../layouts/Layout.astro';
           <nav class="hidden md:flex space-x-6 font-medium">
             <a href="/directorio" class="text-white hover:text-purple-400">Directorio</a>
             <a href="/explorar" class="text-white hover:text-purple-400">Explorar</a>
+            <a href="/favoritos" class="text-white hover:text-purple-400">Favoritos</a>
           </nav>
         </div>
       <!-- DERECHA: Iconos, Perfil y Toggle Mobile -->
@@ -28,7 +29,7 @@ import Layout from '../layouts/Layout.astro';
           </svg>
         </a>
         <!-- Favorito (Desktop) -->
-        <button class="hidden md:inline-flex text-white hover:text-purple-400">Favorito</button>
+        <a href="/favoritos" class="hidden md:inline-flex text-white hover:text-purple-400">Favoritos</a>
         <!-- Avatar + Dropdown -->
         <div class="relative">
           <button id="menu-user" class="w-10 h-10 rounded-full overflow-hidden border-2 border-purple-500 focus:outline-none">
@@ -59,13 +60,14 @@ import Layout from '../layouts/Layout.astro';
     <div id="mobile-menu" class="hidden md:hidden mt-2 space-y-2 pb-4">
       <a href="/directorio" class="block px-4 py-2 text-white hover:bg-gray-800 rounded">Directorio</a>
       <a href="/explorar" class="block px-4 py-2 text-white hover:bg-gray-800 rounded">Explorar</a>
+      <a href="/favoritos" class="block px-4 py-2 text-white hover:bg-gray-800 rounded">Favoritos</a>
       <div class="border-t border-gray-700 pt-2 flex items-center space-x-4 px-4">
         <a href="/buscar" aria-label="Buscar" class="text-white hover:text-purple-400">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-5 h-5" fill="currentColor">
             <path d="M10 2a8 8 0 015.292 13.708l4.147 4.146-1.414 1.415-4.146-4.147A8 8 0 1110 2zm0 2a6 6 0 100 12 6 6 0 000-12z"/>
           </svg>
         </a>
-        <button class="text-white hover:text-purple-400">Favorito</button>
+        <a href="/favoritos" class="text-white hover:text-purple-400">Favoritos</a>
         <a href="/perfil" class="text-white hover:text-purple-400">Perfil</a>
       </div>
     </div>

--- a/src/pages/serie/[slug].astro
+++ b/src/pages/serie/[slug].astro
@@ -43,9 +43,14 @@ interface ReactionRow extends RowDataPacket {
   tipo: string;
 }
 
+interface FavoriteRow extends RowDataPacket {
+  existe: number;
+}
+
 let likes = 0;
 let dislikes = 0;
 let userReaction: string | null = null;
+let isFavorite = false;
 
 const { slug } = Astro.params;
 const usuarioId = Astro.cookies.get('usuario_id')?.value;
@@ -95,6 +100,12 @@ if (usuarioId) {
     [usuarioId, id]
   );
   userReaction = reactionRow?.tipo ?? null;
+
+  const [[favoriteRow]] = await db.query<FavoriteRow[]>(
+    `SELECT 1 AS existe FROM favoritos WHERE usuario_id = ? AND serie_id = ? LIMIT 1`,
+    [usuarioId, id]
+  );
+  isFavorite = Boolean(favoriteRow?.existe);
 }
 ---
 
@@ -123,8 +134,17 @@ if (usuarioId) {
         <p class="text-white text-lg mb-6">{serie.descripcion}</p>
 
         <div class="flex flex-col md:flex-row md:items-center gap-4 md:gap-8">
-          <button class="bg-pink-500 text-white px-4 py-2 rounded">
-            Añadir a Favoritos
+          <button
+            id="favorite-btn"
+            data-serie-id={id}
+            data-favorite={isFavorite}
+            class={`rounded px-4 py-2 font-semibold transition-colors ${
+              isFavorite
+                ? 'bg-purple-700 text-white hover:bg-purple-600'
+                : 'bg-pink-500 text-white hover:bg-pink-400'
+            }`}
+          >
+            {isFavorite ? 'En favoritos' : 'Añadir a Favoritos'}
           </button>
 
           <div
@@ -228,6 +248,41 @@ if (usuarioId) {
     const btnDislike = document.getElementById('btn-dislike');
     const countLike = document.getElementById('count-like');
     const countDislike = document.getElementById('count-dislike');
+    const favoriteBtn = document.getElementById('favorite-btn');
+    let isFavorite = favoriteBtn?.dataset.favorite === 'true';
+
+    favoriteBtn?.addEventListener('click', async () => {
+      if (!favoriteBtn) return;
+      favoriteBtn.textContent = 'Guardando...';
+      favoriteBtn.setAttribute('disabled', 'true');
+
+      try {
+        const res = await fetch(`/api/favoritos/${serieId}`, { method: 'POST' });
+        if (res.status === 401) {
+          window.location.href = '/login';
+          return;
+        }
+        if (!res.ok) throw new Error('No se pudo actualizar');
+        const data = await res.json();
+        isFavorite = data.favorito;
+        updateFavoriteButton();
+      } catch (error) {
+        console.error(error);
+        favoriteBtn.textContent = 'Error';
+      } finally {
+        favoriteBtn?.removeAttribute('disabled');
+      }
+    });
+
+    function updateFavoriteButton() {
+      if (!favoriteBtn) return;
+      favoriteBtn.dataset.favorite = String(isFavorite);
+      favoriteBtn.textContent = isFavorite ? 'En favoritos' : 'Añadir a Favoritos';
+      favoriteBtn.classList.toggle('bg-purple-700', isFavorite);
+      favoriteBtn.classList.toggle('hover:bg-purple-600', isFavorite);
+      favoriteBtn.classList.toggle('bg-pink-500', !isFavorite);
+      favoriteBtn.classList.toggle('hover:bg-pink-400', !isFavorite);
+    }
 
     btnLike.addEventListener('click', () => sendReaction('like'));
     btnDislike.addEventListener('click', () => sendReaction('dislike'));


### PR DESCRIPTION
## Summary
- add API endpoint to toggle favorites per series and surface state in series view
- create a dedicated favorites page that lists saved series and allows removing them
- link the favorites section from the header navigation

## Testing
- npm run build *(fails: missing SSR adapter in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4c845d0c8331a143d4e837d4f50f)