### PR TITLE
Rediseña inicio y corrige interacción del carrusel

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,58 +60,89 @@ try {
 
 <Layout>
   <!-- === Carrusel Destacadas === -->
-  <section class="relative mt-8 h-[550px] overflow-hidden">
+  <section class="relative mt-6 h-[620px] mx-4 overflow-hidden rounded-3xl shadow-2xl ring-1 ring-purple-500/30">
     {featured.map((s, i) => (
       <div
-        class="absolute inset-0 transition-opacity duration-700 ease-in-out"
+        class={`absolute inset-0 transition-all duration-700 ease-in-out ${i === 0 ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
         data-slide={i}
-        style={i === 0 ? '' : 'opacity:0'}
       >
         <img src={s.banner} alt={s.titulo} class="w-full h-full object-cover" />
-        <div class="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent" />
-        <div class="absolute bottom-0 left-0 p-8 text-white max-w-lg">
-          <h2 class="text-4xl font-bold mb-2">{s.titulo}</h2>
-          <p class="mb-4">{s.descripcion.slice(0, 150)}…</p>
-          <a href={`/serie/${s.slug}`} class="bg-purple-600 px-4 py-2 rounded">
-            Ver Detalles
-          </a>
+        <div class="absolute inset-0 bg-gradient-to-r from-black via-black/70 to-black/30" />
+        <div class="absolute inset-x-0 bottom-0 lg:bottom-10 lg:left-12 lg:max-w-2xl p-6 lg:p-0 text-white space-y-4">
+          <div class="flex items-center gap-3 text-sm uppercase tracking-wide text-purple-200/80">
+            <span class="px-3 py-1 rounded-full bg-purple-600/70 backdrop-blur">Destacado</span>
+            <span class="px-3 py-1 rounded-full bg-white/10 border border-white/20">{s.genero}</span>
+          </div>
+          <h2 class="text-4xl lg:text-5xl font-black drop-shadow-lg">{s.titulo}</h2>
+          <p class="text-base text-gray-100/90 leading-relaxed max-w-2xl">{s.descripcion.slice(0, 170)}…</p>
+          <div class="flex flex-wrap gap-3 text-sm text-gray-200/90">
+            <span class="px-3 py-2 rounded-full bg-white/10 border border-white/20">{s.temporada_count} Temporadas</span>
+            <span class="px-3 py-2 rounded-full bg-white/10 border border-white/20">{s.episodio_count} Episodios</span>
+            <span class="px-3 py-2 rounded-full bg-white/10 border border-white/20">Idioma: {s.idioma}</span>
+          </div>
+
+          <div class="flex flex-wrap gap-4 pt-2">
+            <a
+              href={`/serie/${s.slug}`}
+              class="bg-gradient-to-r from-purple-500 to-fuchsia-500 hover:shadow-lg hover:shadow-purple-500/30 px-5 py-3 rounded-xl font-semibold transition-all"
+            >
+              Ver Detalles
+            </a>
+            <button
+              type="button"
+              data-add-carousel={s.slug}
+              class="flex items-center gap-2 px-5 py-3 rounded-xl border border-white/30 bg-white/10 backdrop-blur hover:bg-white/20 transition-all"
+            >
+              <span>➕</span> Agregar al carrucel
+            </button>
+          </div>
         </div>
       </div>
     ))}
 
-    <button id="prevBtn" class="absolute left-4 top-1/2 -translate-y-1/2 bg-black/50 text-white p-3 rounded-full hover:bg-black/70">‹</button>
-    <button id="nextBtn" class="absolute right-4 top-1/2 -translate-y-1/2 bg-black/50 text-white p-3 rounded-full hover:bg-black/70">›</button>
+    <button id="prevBtn" class="absolute left-6 top-1/2 -translate-y-1/2 bg-black/50 text-white p-3 rounded-full hover:bg-black/70 backdrop-blur">‹</button>
+    <button id="nextBtn" class="absolute right-6 top-1/2 -translate-y-1/2 bg-black/50 text-white p-3 rounded-full hover:bg-black/70 backdrop-blur">›</button>
 
-    <div class="absolute bottom-4 left-1/2 -translate-x-1/2 flex space-x-2">
+    <div class="absolute bottom-6 left-1/2 -translate-x-1/2 flex space-x-3">
       {featured.map((_, i) => (
         <span
-          class="w-3 h-3 bg-white/50 rounded-full cursor-pointer"
+          class="w-3 h-3 bg-white/40 rounded-full cursor-pointer border border-white/50"
           data-indicator={i}
           style={i === 0 ? 'background-color: white;' : ''}
         />
       ))}
     </div>
+
+    <div id="carouselToast" class="pointer-events-none fixed top-6 right-6 px-4 py-3 bg-purple-600/90 text-white rounded-xl shadow-lg opacity-0 -translate-y-4 transition-all duration-300">
+      ¡Serie añadida al carrucel!
+    </div>
   </section>
 
   <!-- 2) Nuevos Lanzamientos -->
   <section class="mt-12 px-4">
-    <h2 class="text-white text-2xl font-bold mb-4">Nuevos Lanzamientos</h2>
-    <div class="flex overflow-x-auto space-x-6 snap-x snap-mandatory pb-4">
+    <div class="flex items-center justify-between mb-4">
+      <div>
+        <p class="text-sm uppercase tracking-[0.25em] text-purple-200/70">Explora</p>
+        <h2 class="text-white text-3xl font-extrabold">Nuevos Lanzamientos</h2>
+      </div>
+      <a href="/explorar" class="text-sm text-purple-200 hover:text-white transition">Ver todo →</a>
+    </div>
+    <div class="grid md:grid-cols-3 lg:grid-cols-4 gap-6">
       {recent.map(s => (
         <a
           href={`/serie/${s.slug}`}
-          class="relative group snap-start flex-shrink-0 w-64 lg:w-72 overflow-hidden rounded-lg hover:scale-105 transition-transform duration-500"
+          class="relative group overflow-hidden rounded-2xl bg-gradient-to-b from-white/5 to-white/0 border border-white/10 shadow-xl"
         >
           {s.destacado_reciente && (
-            <span class="absolute top-2 left-2 bg-green-500 text-white text-xs font-bold uppercase px-2 py-1 z-10">Estreno</span>
+            <span class="absolute top-3 left-3 bg-green-500 text-white text-[11px] font-bold uppercase px-2.5 py-1 rounded-full z-10">Estreno</span>
           )}
 
           <img src={s.icon} alt={s.titulo} class="w-full h-64 object-cover z-0" />
-          <div class="absolute bottom-0 w-full h-40 bg-gradient-to-t from-black/60 to-transparent z-0" />
+          <div class="absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-black via-black/70 to-transparent" />
 
-          <div class="absolute bottom-3 left-4 text-white z-10">
-            <h4 class="text-lg font-semibold">{s.titulo}</h4>
-            <p class="text-xs">{s.temporada_count} Temp • {s.episodio_count} Ep</p>
+          <div class="absolute bottom-3 left-4 right-4 text-white z-10 space-y-1">
+            <h4 class="text-lg font-semibold leading-tight">{s.titulo}</h4>
+            <p class="text-xs text-purple-100/90">{s.temporada_count} Temp • {s.episodio_count} Ep</p>
           </div>
 
           <div class="absolute inset-0 bg-black/80 text-white p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col justify-between z-10">
@@ -128,18 +159,24 @@ try {
 
   <!-- 3) Lo Más Popular -->
   <section class="mt-12 px-4">
-    <h2 class="text-white text-2xl font-bold mb-4">Lo Más Popular</h2>
-    <div class="flex overflow-x-auto space-x-6 snap-x snap-mandatory pb-4">
+    <div class="flex items-center justify-between mb-4">
+      <div>
+        <p class="text-sm uppercase tracking-[0.25em] text-purple-200/70">Ranking</p>
+        <h2 class="text-white text-3xl font-extrabold">Lo Más Popular</h2>
+      </div>
+      <a href="/explorar?tab=popular" class="text-sm text-purple-200 hover:text-white transition">Top 10 →</a>
+    </div>
+    <div class="grid md:grid-cols-3 lg:grid-cols-4 gap-6">
       {popular.map(s => (
         <a
           href={`/serie/${s.slug}`}
-          class="relative group snap-start flex-shrink-0 w-80 lg:w-72 overflow-hidden rounded-lg hover:scale-105 transition-transform duration-500"
+          class="relative group overflow-hidden rounded-2xl bg-gradient-to-b from-white/5 to-white/0 border border-white/10 shadow-xl"
         >
           <img src={s.icon} alt={s.titulo} class="w-full h-64 object-cover z-0" />
-          <div class="absolute bottom-0 w-full h-40 bg-gradient-to-t from-black/60 to-transparent z-0" />
-          <div class="absolute bottom-3 left-4 text-white z-10">
-            <h4 class="text-lg font-semibold">{s.titulo}</h4>
-            <p class="text-xs">★ {s.total_likes} likes • {s.temporada_count} Temp • {s.episodio_count} Ep</p>
+          <div class="absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-black via-black/70 to-transparent" />
+          <div class="absolute bottom-3 left-4 right-4 text-white z-10 space-y-1">
+            <h4 class="text-lg font-semibold leading-tight">{s.titulo}</h4>
+            <p class="text-xs text-purple-100/90">★ {s.total_likes} likes • {s.temporada_count} Temp • {s.episodio_count} Ep</p>
           </div>
 
         <div class="absolute inset-0 bg-black/80 text-white p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col justify-between z-10">
@@ -155,19 +192,25 @@ try {
   </section>
 
   <!-- 4) Directorio Completo -->
-  <section class="mt-12 px-4 pb-12">
-    <h2 class="text-white text-2xl font-bold mb-4">Directorio Completo</h2>
+  <section class="mt-12 px-4 pb-14">
+    <div class="flex items-center justify-between mb-4">
+      <div>
+        <p class="text-sm uppercase tracking-[0.25em] text-purple-200/70">Catálogo</p>
+        <h2 class="text-white text-3xl font-extrabold">Directorio Completo</h2>
+      </div>
+      <a href="/directorio" class="text-sm text-purple-200 hover:text-white transition">Ver directorio →</a>
+    </div>
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-6">
       {allSeries.map(s => (
         <a
           href={`/serie/${s.slug}`}
-          class="relative group overflow-hidden rounded-lg hover:scale-105 transition-transform duration-500"
+          class="relative group overflow-hidden rounded-2xl bg-gradient-to-b from-white/5 to-white/0 border border-white/10 shadow-lg"
         >
-          <img src={s.icon} alt={s.titulo} class="w-full h-64 object-cover z-0" />
-          <div class="absolute bottom-0 w-full h-40 bg-gradient-to-t from-black/60 to-transparent z-0" />
-          <div class="absolute bottom-3 left-4 text-white z-10">
-            <h4 class="text-lg font-semibold">{s.titulo}</h4>
-            <p class="text-xs">{s.temporada_count} Temp • {s.episodio_count} Ep</p>
+          <img src={s.icon} alt={s.titulo} class="w-full h-60 object-cover z-0" />
+          <div class="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-black via-black/70 to-transparent" />
+          <div class="absolute bottom-3 left-3 right-3 text-white z-10 space-y-1">
+            <h4 class="text-sm font-semibold leading-tight">{s.titulo}</h4>
+            <p class="text-[11px] text-purple-100/90">{s.temporada_count} Temp • {s.episodio_count} Ep</p>
           </div>
         <div class="absolute inset-0 bg-black/80 text-white p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col justify-between z-10">
             <div>
@@ -185,20 +228,51 @@ try {
     document.addEventListener('DOMContentLoaded', () => {
       const slides = document.querySelectorAll('[data-slide]');
       const dots   = document.querySelectorAll('[data-indicator]');
+      const toast  = document.getElementById('carouselToast');
       let idx = 0;
 
-      function showSlide(newIdx) {
-        slides[idx].style.opacity = 0;
-        dots[idx].style.backgroundColor = '';
-        idx = (newIdx + slides.length) % slides.length;
-        slides[idx].style.opacity = 1;
-        dots[idx].style.backgroundColor = 'white';
+      function setActiveSlide(activeIdx) {
+        slides.forEach((slide, position) => {
+          const active = position === activeIdx;
+          slide.style.opacity = active ? 1 : 0;
+          slide.style.pointerEvents = active ? 'auto' : 'none';
+        });
+        dots.forEach((dot, position) => {
+          dot.style.backgroundColor = position === activeIdx ? 'white' : '';
+        });
       }
 
-      document.getElementById('prevBtn').addEventListener('click', () => showSlide(idx - 1));
-      document.getElementById('nextBtn').addEventListener('click', () => showSlide(idx + 1));
+      function showSlide(newIdx) {
+        idx = (newIdx + slides.length) % slides.length;
+        setActiveSlide(idx);
+      }
 
+      document.getElementById('prevBtn')?.addEventListener('click', () => showSlide(idx - 1));
+      document.getElementById('nextBtn')?.addEventListener('click', () => showSlide(idx + 1));
       dots.forEach(dot => dot.addEventListener('click', () => showSlide(Number(dot.dataset.indicator))));
+
+      const addButtons = document.querySelectorAll('[data-add-carousel]');
+      addButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const slug = btn.dataset.addCarousel;
+          const stored = JSON.parse(localStorage.getItem('carrucelSeleccion') || '[]');
+          if (!stored.includes(slug)) {
+            stored.push(slug);
+            localStorage.setItem('carrucelSeleccion', JSON.stringify(stored));
+          }
+          if (toast) {
+            toast.textContent = `${slug} añadido al carrucel`;
+            toast.classList.remove('opacity-0', '-translate-y-4');
+            toast.classList.add('opacity-100', 'translate-y-0');
+            setTimeout(() => {
+              toast.classList.add('opacity-0', '-translate-y-4');
+              toast.classList.remove('opacity-100', 'translate-y-0');
+            }, 2200);
+          }
+        });
+      });
+
+      setActiveSlide(idx);
     });
   </script>
 </Layout>


### PR DESCRIPTION
## Summary
- rediseño visual de la sección principal con CTA para agregar series al carrucel
- ajustes en las secciones de lanzamientos, populares y directorio con tarjetas mejoradas
- correcciones en el carrucel para evitar clics fantasma y permitir guardar selecciones locales

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c5338a400833198ea35c1d4570401)