### PR TITLE
Fix episodes loading when switching seasons

### DIFF
--- a/src/pages/serie/[slug].astro
+++ b/src/pages/serie/[slug].astro
@@ -362,7 +362,8 @@ if (usuarioId) {
         const temporadaId = e.target.value;
         const res = await fetch(`/api/episodios/${temporadaId}`);
         if (!res.ok) throw new Error('Error al cargar episodios');
-        const nuevos = await res.json();
+        const data = await res.json();
+        const nuevos = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : [];
 
         let html = '';
         if (nuevos.length > 0) {


### PR DESCRIPTION
## Summary
- handle episodios API responses that wrap data to keep season changes working

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c56681fd4833190a902ad8a0667cd)