### PR TITLE
Rediseña directorio, explorar y menú de perfil

### DIFF
--- a/src/pages/directorio.astro
+++ b/src/pages/directorio.astro
@@ -29,58 +29,87 @@ const series = Array.isArray(allSeries) ? allSeries : [];
 ---
 
 <Layout>
-  <div class="container mx-auto px-4 py-8">
-    <h1 class="text-3xl font-bold mb-8 text-white">Directorio de Series</h1>
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
+  <section class="container mx-auto px-4 py-12 space-y-10">
+    <div class="relative overflow-hidden rounded-2xl bg-gradient-to-r from-purple-900/80 via-indigo-900/70 to-slate-900/80 p-8 border border-white/5 shadow-2xl">
+      <div class="absolute inset-0 opacity-30 blur-3xl bg-[radial-gradient(circle_at_top,_rgba(167,139,250,0.4),_transparent_40%),_radial-gradient(circle_at_bottom,_rgba(56,189,248,0.35),_transparent_45%)]"></div>
+      <div class="relative grid lg:grid-cols-3 gap-6 items-center">
+        <div class="lg:col-span-2 space-y-4">
+          <p class="text-sm uppercase tracking-[0.3em] text-purple-200/70">Directorio</p>
+          <h1 class="text-4xl sm:text-5xl font-extrabold text-white leading-tight">Descubre todas las series disponibles</h1>
+          <p class="text-gray-200/80 text-lg max-w-2xl">Explora el catálogo completo organizado con detalles rápidos de temporadas, episodios y una vista previa mejorada.</p>
+          <div class="flex flex-wrap gap-3 text-sm text-white/80">
+            <span class="px-4 py-2 rounded-full bg-white/5 border border-white/10 backdrop-blur">{series.length} series disponibles</span>
+            <span class="px-4 py-2 rounded-full bg-white/5 border border-white/10 backdrop-blur flex items-center gap-2">
+              <span class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span> Catálogo siempre actualizado
+            </span>
+          </div>
+        </div>
+        <div class="grid grid-cols-2 gap-3 text-center">
+          <div class="rounded-xl bg-black/40 border border-white/10 p-4 shadow-lg">
+            <p class="text-sm text-gray-300">Promedio de temporadas</p>
+            <p class="text-3xl font-bold text-white">{Math.round(series.reduce((acc, s) => acc + s.temporada_count, 0) / (series.length || 1))}</p>
+          </div>
+          <div class="rounded-xl bg-black/40 border border-white/10 p-4 shadow-lg">
+            <p class="text-sm text-gray-300">Total episodios</p>
+            <p class="text-3xl font-bold text-white">{series.reduce((acc, s) => acc + s.episodio_count, 0)}</p>
+          </div>
+          <div class="col-span-2 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-500 p-[1px] shadow-lg">
+            <div class="rounded-[11px] bg-slate-900/80 p-4 h-full flex items-center justify-between">
+              <div class="text-left">
+                <p class="text-sm text-purple-100">Consejo</p>
+                <p class="text-lg font-semibold text-white">Usa las tarjetas para obtener detalles al instante</p>
+              </div>
+              <svg class="w-10 h-10 text-purple-200" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2" />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {series.map((serie: Serie) => (
         <a
           href={`/serie/${serie.slug}`}
-          class="relative block bg-gray-800 rounded-lg overflow-hidden hover:scale-105 transition-transform duration-300 group shadow-lg"
+          class="group relative block rounded-2xl overflow-hidden border border-white/5 bg-gradient-to-b from-slate-900/80 to-slate-950/90 shadow-xl transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl hover:border-purple-400/40"
         >
           <div class="aspect-[3/4] relative">
-            <img 
-              src={serie.icon || '/avatar.jpeg'} 
-              alt={serie.titulo} 
-              class="w-full h-full object-cover"
+            <img
+              src={serie.icon || '/avatar.jpeg'}
+              alt={serie.titulo}
+              class="w-full h-full object-cover transition duration-500 group-hover:scale-105"
               onerror="this.src='/avatar.jpeg'"
             />
-            {/* Conteo y título sobre imagen */}
-            <div class="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black/90 via-black/60 to-transparent p-4">
-              <h3 class="text-white font-semibold text-lg truncate mb-1">{serie.titulo}</h3>
-              <p class="text-gray-300 text-sm">
-                <span class="inline-flex items-center">
-                  <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
-                    <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
-                    <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
-                  </svg>
-                  {serie.temporada_count} Temp • {serie.episodio_count} Ep
-                </span>
+            <div class="absolute inset-0 bg-gradient-to-t from-black via-black/30 to-transparent opacity-70 group-hover:opacity-90 transition" />
+            <div class="absolute top-3 right-3 flex gap-2">
+              <span class="px-3 py-1 text-xs font-semibold rounded-full bg-white/15 border border-white/20 backdrop-blur">{serie.temporada_count} Temp</span>
+              <span class="px-3 py-1 text-xs font-semibold rounded-full bg-white/15 border border-white/20 backdrop-blur">{serie.episodio_count} Ep</span>
+            </div>
+            <div class="absolute bottom-0 left-0 right-0 p-4 space-y-1">
+              <p class="text-xs uppercase tracking-wide text-purple-200/80">Serie</p>
+              <h3 class="text-xl font-bold text-white drop-shadow-sm line-clamp-2">{serie.titulo}</h3>
+              <p class="text-sm text-gray-200/80 line-clamp-2">
+                {serie.descripcion || 'Descripción no disponible'}
               </p>
             </div>
           </div>
-          
-          {/* Overlay interactivo al hover */}
-          <div class="absolute inset-0 bg-black/90 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col justify-center items-center p-6 text-center">
-            <h3 class="text-xl font-bold text-white mb-3">{serie.titulo}</h3>
-            {serie.descripcion && (
-              <p class="text-gray-300 text-sm mb-4 line-clamp-3">
-                {serie.descripcion}
-              </p>
-            )}
-            <div class="flex gap-2 text-gray-400 text-xs mb-4">
-            <span class="inline-block px-2 py-1 bg-gray-800 rounded-full">{serie.temporada_count} Temporadas</span>
-            <span class="inline-block px-2 py-1 bg-gray-800 rounded-full">{serie.episodio_count} Episodios</span>
-          </div>
-            <span
-              class="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2 rounded-full font-medium transition-colors duration-300"
-            >
-              Ver
-            </span>
+
+          <div class="absolute inset-x-0 bottom-0 translate-y-full group-hover:translate-y-0 transition-transform duration-300">
+            <div class="m-3 rounded-xl bg-white/10 backdrop-blur border border-white/10 p-3 flex items-center justify-between text-sm text-white">
+              <span class="flex items-center gap-2">
+                <svg class="w-5 h-5 text-purple-200" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                </svg>
+                Ver detalles
+              </span>
+              <span class="px-3 py-1 rounded-full bg-purple-600 text-xs font-semibold shadow-lg">Entrar</span>
+            </div>
           </div>
         </a>
       ))}
     </div>
-  </div>
+  </section>
 </Layout>
 
 <style>

--- a/src/pages/explorar.astro
+++ b/src/pages/explorar.astro
@@ -53,69 +53,90 @@ const lista = Array.isArray(series) ? series : [];
 ---
 
 <Layout>
-  <div class="mt-24 px-4">
-    <!-- Título y Ordenar menú -->
-    <div class="flex items-center justify-between mb-8">
-      <h1 class="text-3xl font-bold text-white">Explorar Series</h1>
-      <div class="relative">
-        <button id="sort-toggle" class="flex items-center space-x-2 bg-gray-700 text-gray-200 px-4 py-2 rounded hover:bg-gray-600">
-          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-            <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-1.447.894l-2-1A1 1 0 018 14v-2.586L3.293 6.707A1 1 0 013 6V4z"/>
-          </svg>
-          <span>{tituloOrden}</span>
-        </button>
-        <ul id="sort-menu" class="hidden absolute right-0 mt-1 bg-gray-900 text-white rounded shadow-lg w-48 z-50">
-          <li class="px-4 py-2 cursor-pointer hover:bg-gray-800" data-value="popular">Popularidad</li>
-          <li class="px-4 py-2 cursor-pointer hover:bg-gray-800" data-value="reciente">Lo más reciente</li>
-          <li class="px-4 py-2 cursor-pointer hover:bg-gray-800" data-value="antiguo">Más antiguas</li>
-        </ul>
+  <section class="mt-24 px-4 pb-12 space-y-10">
+    <div class="relative overflow-hidden rounded-2xl border border-white/5 bg-gradient-to-r from-indigo-900/80 via-purple-900/70 to-slate-900/80 p-8 shadow-2xl">
+      <div class="absolute inset-0 opacity-40 blur-3xl bg-[radial-gradient(circle_at_20%_30%,_rgba(129,140,248,0.35),_transparent_45%),_radial-gradient(circle_at_80%_40%,_rgba(248,113,113,0.35),_transparent_45%)]"></div>
+      <div class="relative grid lg:grid-cols-3 gap-8 items-center">
+        <div class="lg:col-span-2 space-y-4">
+          <p class="text-sm uppercase tracking-[0.35em] text-indigo-100/80">Explorar</p>
+          <h1 class="text-4xl sm:text-5xl font-extrabold text-white leading-tight">Explora las series por {tituloOrden.toLowerCase()}</h1>
+          <p class="text-lg text-indigo-50/90 max-w-2xl">Intercambia el orden fácilmente y descubre nuevas historias con una rejilla enfocada en mostrar la información clave de cada anime.</p>
+          <div class="flex flex-wrap gap-2">
+            {['popular', 'reciente', 'antiguo'].map(opcion => (
+              <button
+                data-filtro={opcion}
+                class={`orden-btn px-4 py-2 rounded-full border transition-all duration-200 ${orden === opcion ? 'bg-white text-slate-900 font-semibold border-white' : 'bg-white/10 text-white border-white/20 hover:border-white/60'}`}
+              >
+                {opcion === 'popular' ? 'Popularidad' : opcion === 'reciente' ? 'Lo más reciente' : 'Más antiguas'}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div class="grid grid-cols-2 gap-3 text-center">
+          <div class="rounded-xl bg-black/40 border border-white/10 p-4 shadow-lg">
+            <p class="text-sm text-gray-300">Total de series</p>
+            <p class="text-3xl font-bold text-white">{lista.length}</p>
+          </div>
+          <div class="rounded-xl bg-black/40 border border-white/10 p-4 shadow-lg">
+            <p class="text-sm text-gray-300">Episodios promedio</p>
+            <p class="text-3xl font-bold text-white">{Math.round(lista.reduce((acc, s) => acc + s.episodio_count, 0) / (lista.length || 1))}</p>
+          </div>
+          <div class="col-span-2 rounded-xl bg-white/10 border border-white/15 p-4 flex items-center gap-3 text-left">
+            <div class="w-12 h-12 rounded-full bg-purple-500/30 flex items-center justify-center text-white">
+              <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+              </svg>
+            </div>
+            <div>
+              <p class="text-sm text-purple-100">Tip rápido</p>
+              <p class="text-base text-white">Elige un filtro para reorganizar la rejilla al instante.</p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
-    <!-- Grid de series -->
-    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-6">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {lista.map(serie => (
-        <a href={`/serie/${serie.slug}`} class="relative group block rounded overflow-hidden bg-gray-800 hover:scale-105 transition">
+        <a href={`/serie/${serie.slug}`} class="group relative block rounded-2xl overflow-hidden bg-gradient-to-b from-slate-950/80 to-black/80 border border-white/5 shadow-xl transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl hover:border-indigo-400/40">
           <div class="aspect-[3/4] relative">
-            <img src={serie.icon || '/avatar.jpeg'} alt={serie.titulo} class="w-full h-full object-cover" onerror="this.src='/avatar.jpeg'" />
+            <img src={serie.icon || '/avatar.jpeg'} alt={serie.titulo} class="w-full h-full object-cover transition duration-500 group-hover:scale-105" onerror="this.src='/avatar.jpeg'" />
             {orden === 'popular' && serie.total_likes !== undefined && (
-              <span class="absolute top-2 left-2 bg-yellow-500 text-black text-xs font-bold uppercase px-2 py-1 z-20">★ {serie.total_likes}</span>
+              <span class="absolute top-3 left-3 bg-yellow-400 text-black text-xs font-bold uppercase px-3 py-1 rounded-full shadow-lg">★ {serie.total_likes}</span>
             )}
-            <div class="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black/80 to-transparent p-3">
-              <h3 class="text-white font-semibold truncate">{serie.titulo}</h3>
-              <p class="text-gray-300 text-xs truncate">{serie.temporada_count} Temp • {serie.episodio_count} Ep</p>
-            </div>
-
-            <!-- Overlay interactivo al hover -->
-            <div class="absolute inset-0 bg-black/90 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col justify-center items-center p-6 text-center">
-              <h3 class="text-xl font-bold text-white mb-3">{serie.titulo}</h3>
-              {serie.descripcion && (
-                <p class="text-gray-300 text-sm mb-4 line-clamp-3">{serie.descripcion}</p>
-              )}
-              <div class="flex gap-2 text-gray-400 text-xs mb-4">
-                <span class="inline-block px-2 py-1 bg-gray-800 rounded-full">{serie.temporada_count} Temporadas</span>
-                <span class="inline-block px-2 py-1 bg-gray-800 rounded-full">{serie.episodio_count} Episodios</span>
+            <div class="absolute inset-0 bg-gradient-to-t from-black via-black/30 to-transparent opacity-75 group-hover:opacity-90 transition" />
+            <div class="absolute bottom-0 left-0 right-0 p-4 space-y-2">
+              <p class="text-xs uppercase tracking-wide text-indigo-100/80">Anime</p>
+              <h3 class="text-xl font-bold text-white drop-shadow line-clamp-2">{serie.titulo}</h3>
+              <p class="text-sm text-gray-200/80 line-clamp-2">{serie.descripcion || 'Sin descripción por ahora.'}</p>
+              <div class="flex gap-2 text-gray-200 text-xs">
+                <span class="inline-flex items-center px-3 py-1 rounded-full bg-white/10 border border-white/15 backdrop-blur">{serie.temporada_count} Temp</span>
+                <span class="inline-flex items-center px-3 py-1 rounded-full bg-white/10 border border-white/15 backdrop-blur">{serie.episodio_count} Ep</span>
               </div>
-              <button class="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2 rounded-full font-medium transition-colors duration-300">Ver Anime</button>
             </div>
-
+            <div class="absolute inset-x-0 bottom-0 translate-y-full group-hover:translate-y-0 transition-transform duration-300">
+              <div class="m-3 rounded-xl bg-white/10 backdrop-blur border border-white/10 p-3 flex items-center justify-between text-sm text-white">
+                <span class="flex items-center gap-2">
+                  <svg class="w-5 h-5 text-indigo-200" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  Ver detalles
+                </span>
+                <span class="px-3 py-1 rounded-full bg-indigo-500 text-xs font-semibold shadow-lg">Entrar</span>
+              </div>
+            </div>
           </div>
         </a>
       ))}
     </div>
-  </div>
+  </section>
 
   <script type="module">
     document.addEventListener('DOMContentLoaded', () => {
-      const toggle = document.getElementById('sort-toggle');
-      const menu = document.getElementById('sort-menu');
-      toggle.addEventListener('click', () => menu.classList.toggle('hidden'));
-      document.addEventListener('click', e => {
-        if (!menu.contains(e.target) && e.target !== toggle) menu.classList.add('hidden');
-      });
-      menu.querySelectorAll('li').forEach(li => {
-        li.addEventListener('click', () => {
-          const val = li.getAttribute('data-value');
+      const buttons = document.querySelectorAll('.orden-btn');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const val = btn.getAttribute('data-filtro');
           if (val) window.location.search = `?filtro=${val}`;
         });
       });

--- a/src/pages/header.astro
+++ b/src/pages/header.astro
@@ -31,18 +31,44 @@ import Layout from '../layouts/Layout.astro';
         <a href="/favoritos" class="hidden md:inline-flex text-white hover:text-purple-400">Favoritos</a>
         <!-- Avatar + Dropdown -->
         <div class="relative">
-          <button id="menu-user" class="w-10 h-10 rounded-full overflow-hidden border-2 border-purple-500 focus:outline-none">
+          <button
+            id="menu-user"
+            class="w-11 h-11 rounded-full overflow-hidden border-2 border-purple-500/80 bg-black/40 backdrop-blur shadow-lg shadow-purple-500/30 ring-2 ring-purple-500/20 hover:ring-purple-400/50 transition duration-200 focus:outline-none"
+          >
             <img id="user-avatar" src="/avatar.jpeg" alt="User avatar" class="w-full h-full object-cover" />
           </button>
-          <div id="dropdown-menu" class="hidden absolute right-0 mt-2 w-44 bg-black text-white rounded-md shadow-lg overflow-hidden z-50">
-            <div id="logged-out-menu">
-              <a href="/login" class="block px-4 py-2 hover:bg-gray-800">Logearse</a>
-              <a href="/register" class="block px-4 py-2 hover:bg-gray-800">Registrarse</a>
+          <div
+            id="dropdown-menu"
+            class="hidden absolute right-0 mt-3 w-56 bg-gradient-to-b from-slate-900 to-black text-white rounded-xl shadow-2xl overflow-hidden z-50 border border-white/10 transform origin-top-right scale-95 opacity-0 transition-all duration-200"
+          >
+            <div class="px-4 py-3 border-b border-white/10 bg-white/5 flex items-center gap-3">
+              <div class="w-10 h-10 rounded-full overflow-hidden border border-white/20">
+                <img id="menu-avatar" src="/avatar.jpeg" alt="avatar mini" class="w-full h-full object-cover" />
+              </div>
+              <div class="text-sm leading-tight">
+                <p class="text-white font-semibold">Tu perfil</p>
+                <p class="text-white/70">Accesos rápidos</p>
+              </div>
             </div>
-            <div id="logged-in-menu" class="hidden">
-              <a href="/perfil" class="block px-4 py-2 hover:bg-gray-800">Perfil</a>
-              <a href="/admin" id="admin-panel" class="block px-4 py-2 hover:bg-gray-800 hidden">Panel</a>
-              <button id="logout-btn" class="w-full text-left px-4 py-2 hover:bg-gray-800">Cerrar sesión</button>
+            <div id="logged-out-menu" class="py-2">
+              <a href="/login" class="block px-4 py-2 hover:bg-white/10">Logearse</a>
+              <a href="/register" class="block px-4 py-2 hover:bg-white/10">Registrarse</a>
+            </div>
+            <div id="logged-in-menu" class="hidden py-2">
+              <a href="/perfil" class="block px-4 py-2 hover:bg-white/10">Perfil</a>
+              <a href="/admin" id="admin-panel" class="block px-4 py-2 hover:bg-white/10 hidden">Panel</a>
+              <button id="logout-btn" class="w-full text-left px-4 py-2 hover:bg-white/10">Cerrar sesión</button>
+            </div>
+            <div class="px-4 pb-4">
+              <a
+                href="/perfil"
+                class="flex items-center justify-between px-4 py-3 rounded-lg bg-purple-600 hover:bg-purple-700 transition text-sm font-semibold shadow-lg shadow-purple-500/30"
+              >
+                Ir a mi perfil
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+              </a>
             </div>
           </div>
         </div>
@@ -83,19 +109,31 @@ import Layout from '../layouts/Layout.astro';
       const logoutBtn = document.getElementById('logout-btn');
       const adminPanel = document.getElementById('admin-panel');
       const avatar = document.getElementById('user-avatar');
+      const menuAvatar = document.getElementById('menu-avatar');
 
       toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-      userBtn.addEventListener('click', e => { e.stopPropagation(); dropdown.classList.toggle('hidden'); });
-      document.addEventListener('click', e => { if (!dropdown.contains(e.target) && !userBtn.contains(e.target)) dropdown.classList.add('hidden'); });
+      const toggleDropdown = (show?: boolean) => {
+        const shouldShow = show ?? dropdown.classList.contains('hidden');
+        dropdown.classList.toggle('hidden', !shouldShow);
+        dropdown.classList.toggle('opacity-0', !shouldShow);
+        dropdown.classList.toggle('scale-95', !shouldShow);
+      };
+
+      userBtn.addEventListener('click', e => { e.stopPropagation(); toggleDropdown(); });
+      document.addEventListener('click', e => { if (!dropdown.contains(e.target) && !userBtn.contains(e.target)) toggleDropdown(false); });
 
       fetch('/api/user').then(res => res.json()).then(user => {
         if (user.nickname) {
           avatar.src = user.imagen || '/avatar.svg';
+          if (menuAvatar) menuAvatar.src = user.imagen || '/avatar.svg';
           loggedOut.classList.add('hidden');
           loggedIn.classList.remove('hidden');
           if (user.es_admin === 1) adminPanel.classList.remove('hidden');
         }
-      }).catch(() => { avatar.src = '/avatar.jpeg'; });
+      }).catch(() => {
+        avatar.src = '/avatar.jpeg';
+        if (menuAvatar) menuAvatar.src = '/avatar.jpeg';
+      });
 
       logoutBtn.addEventListener('click', () => fetch('/api/logout',{method:'POST'}).then(()=> location.reload()));
     });


### PR DESCRIPTION
## Summary
- Rediseño visual del directorio con hero de estadísticas y tarjetas detalladas para cada serie.
- Nuevo layout de explorar con filtros destacados y tarjetas animadas con contadores y likes.
- Mejora del botón/flotante de perfil con panel estilizado, avatar duplicado y transición suavizada.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5e5813388331ad968908659f2db9)