### PR TITLE
Rediseña la vista de episodio de serie

### DIFF
--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -62,81 +62,191 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
 ---
 
 <Layout class="bg-black text-white">
-  <section class="mt-30 max-w-5xl mx-auto px-8 py-10 grid lg:grid-cols-3 gap-8">
-    <!-- Columna principal -->
-    <div class="lg:col-span-2 space-y-6">
-      <!-- Video player -->
-      <div class="aspect-video bg-black rounded overflow-hidden">
-        <video
-          id="video-player"
-          controls
-          poster={ep.imagen_preview}
-          data-video-url={ep.video_url}
-          class="w-full h-full"
-        >
-          Tu navegador no soporta la reproducción de video.
-        </video>
+  <section class="relative isolate overflow-hidden bg-gradient-to-b from-indigo-950/70 via-black to-black">
+    <div
+      class="pointer-events-none absolute inset-0 opacity-25"
+      style={`background-image: radial-gradient(circle at 20% 20%, #7c3aed 0, transparent 30%), radial-gradient(circle at 80% 0%, #22d3ee 0, transparent 25%), radial-gradient(circle at 50% 80%, #10b981 0, transparent 25%);`}
+    ></div>
+    <div class="relative mx-auto max-w-6xl px-6 pb-14 pt-16 lg:px-10 lg:pt-20">
+      <div class="mb-8 flex flex-wrap items-center gap-3 text-sm text-gray-300">
+        <a href={`/serie/${slug}`} class="rounded-full bg-white/10 px-3 py-1 transition hover:bg-white/20">
+          {serie.titulo}
+        </a>
+        <span class="h-1 w-1 rounded-full bg-gray-500"></span>
+        <span class="rounded-full bg-purple-500/20 px-3 py-1 text-purple-100">Episodio {index + 1}</span>
+        <span class="h-1 w-1 rounded-full bg-gray-500"></span>
+        <span class="rounded-full bg-white/10 px-3 py-1">{ep.idioma}</span>
       </div>
 
-      <!-- Encabezado de episodio -->
-      <div class="space-y-2">
-        <h2 class="text-2xl font-bold">{ep.titulo}</h2>
-        <p class="text-gray-400">
-          {ep.idioma} • {ep.duracion} min • Lanzado el{' '}
-          {new Date(ep.fecha_estreno).toLocaleDateString()}
-        </p>
-        <div
-          id="reactions"
-          data-serie-id={serieId}
-          data-user-id={usuarioId}
-          data-user-reaction={userReaction}
-          class="flex items-center space-x-4"
-        >
-          <!-- BOTONES LIKE/DISLIKE -->
+      <div class="grid gap-10 lg:grid-cols-[1.7fr,1fr]">
+        <div class="space-y-6">
+          <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-gray-900 via-gray-900 to-indigo-950 shadow-2xl shadow-purple-900/30">
+            <div class="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.08),transparent_35%),radial-gradient(circle_at_80%_0%,rgba(124,58,237,0.25),transparent_35%)]"></div>
+            <div class="relative">
+              <div class="aspect-video bg-black/80">
+                <video
+                  id="video-player"
+                  controls
+                  poster={ep.imagen_preview}
+                  data-video-url={ep.video_url}
+                  class="h-full w-full rounded-3xl"
+                >
+                  Tu navegador no soporta la reproducción de video.
+                </video>
+              </div>
+              <div class="flex flex-wrap items-center justify-between gap-3 px-6 py-4 text-sm text-gray-300">
+                <div class="flex items-center gap-3">
+                  <span class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-emerald-200">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+                      <path d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm0 1.5a8.25 8.25 0 1 1 0 16.5 8.25 8.25 0 0 1 0-16.5Zm-.75 3a.75.75 0 0 0-.75.75v6.376a.75.75 0 0 0 .371.644l4.5 2.623a.75.75 0 0 0 .758-1.295l-4.129-2.406V7.5a.75.75 0 0 0-.75-.75Z" />
+                    </svg>
+                    {ep.duracion} min
+                  </span>
+                  <span class="inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-blue-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+                      <path d="M12 3c-4.97 0-9 3.134-9 7s4.03 7 9 7c.456 0 .904-.025 1.345-.07l3.362 2.24a.75.75 0 0 0 1.155-.628v-3.191C19.8 13.833 21 11.568 21 10c0-3.866-4.03-7-9-7Zm0 1.5c4.207 0 7.5 2.514 7.5 5.5 0 1.341-.911 3.047-2.64 4.205a.75.75 0 0 0-.336.624v2.05l-2.705-1.806a.75.75 0 0 0-.584-.1A9.3 9.3 0 0 1 12 16.5c-4.207 0-7.5-2.514-7.5-5.5S7.793 4.5 12 4.5Zm-3 4.75a.75.75 0 0 0 0 1.5h6a.75.75 0 0 0 0-1.5H9Z" />
+                    </svg>
+                    {ep.idioma}
+                  </span>
+                </div>
+                <span class="inline-flex items-center gap-2 text-xs uppercase tracking-wide text-gray-400">
+                  Lanzado el {new Date(ep.fecha_estreno).toLocaleDateString()}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div class="space-y-3">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <p class="text-sm uppercase tracking-[0.18em] text-purple-300">Episodio</p>
+                <h2 class="text-3xl font-semibold leading-tight text-white">{ep.titulo}</h2>
+              </div>
+              <div
+                id="reactions"
+                data-serie-id={serieId}
+                data-user-id={usuarioId}
+                data-user-reaction={userReaction}
+                class="flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm shadow-inner"
+              >
+                <!-- BOTONES LIKE/DISLIKE -->
+              </div>
+            </div>
+            <p class="leading-relaxed text-gray-200">{serie.descripcion}</p>
+          </div>
+
+          <div class="grid gap-4 md:grid-cols-3">
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-inner">
+              <p class="text-sm text-gray-400">Clasificación</p>
+              <p class="text-lg font-semibold text-white">{serie.clasificacion_edad}</p>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-inner">
+              <p class="text-sm text-gray-400">Género</p>
+              <p class="text-lg font-semibold text-white">{serie.genero}</p>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-inner">
+              <p class="text-sm text-gray-400">Idioma</p>
+              <p class="text-lg font-semibold text-white">{ep.idioma}</p>
+            </div>
+          </div>
+
+          <div class="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-inner">
+            <div class="mb-3 flex items-center justify-between">
+              <h3 class="text-lg font-semibold text-white">Navegación</h3>
+              <a
+                href={`/serie/${slug}`}
+                class="rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-900/40 transition hover:-translate-y-0.5 hover:bg-purple-500"
+              >
+                Ver más episodios
+              </a>
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+              <div class={`group flex items-center gap-3 rounded-2xl border border-white/10 bg-gradient-to-r from-white/10 to-white/5 p-4 transition${prevEp ? ' hover:-translate-y-1 hover:border-purple-400/40 hover:shadow-lg hover:shadow-purple-900/30' : ''}`}>
+                <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10 text-lg font-semibold text-gray-300">
+                  ←
+                </div>
+                <div>
+                  <p class="text-xs uppercase tracking-widest text-gray-400">Episodio anterior</p>
+                  {prevEp ? (
+                    <a href={`/serie/${slug}/${prevEp.id}`} class="text-base font-semibold text-white transition group-hover:text-purple-200">
+                      {prevEp.titulo}
+                    </a>
+                  ) : (
+                    <span class="text-sm text-gray-500">Este es el primer episodio.</span>
+                  )}
+                </div>
+              </div>
+
+              <div class={`group flex items-center gap-3 rounded-2xl border border-white/10 bg-gradient-to-r from-white/10 to-white/5 p-4 transition${nextEp ? ' hover:-translate-y-1 hover:border-emerald-400/40 hover:shadow-lg hover:shadow-emerald-900/30' : ''}`}>
+                <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10 text-lg font-semibold text-gray-300">
+                  →
+                </div>
+                <div>
+                  <p class="text-xs uppercase tracking-widest text-gray-400">Siguiente episodio</p>
+                  {nextEp ? (
+                    <a href={`/serie/${slug}/${nextEp.id}`} class="text-base font-semibold text-white transition group-hover:text-emerald-200">
+                      {nextEp.titulo}
+                    </a>
+                  ) : (
+                    <span class="text-sm text-gray-500">Este es el último episodio.</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
 
-      <!-- Descripción -->
-      <p class="text-gray-200 leading-relaxed">{serie.descripcion}</p>
+        <aside class="space-y-5">
+          <div class="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-inner">
+            <div class="mb-4 flex items-center gap-3">
+              <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-2xl">🎬</span>
+              <div>
+                <p class="text-sm uppercase tracking-[0.22em] text-gray-400">Serie</p>
+                <h3 class="text-xl font-semibold text-white">{serie.titulo}</h3>
+              </div>
+            </div>
+            <div class="space-y-2 text-sm text-gray-200">
+              <p><span class="text-gray-400">Idioma original:</span> {serie.idioma}</p>
+              <p><span class="text-gray-400">Género:</span> {serie.genero}</p>
+              <p><span class="text-gray-400">Clasificación:</span> {serie.clasificacion_edad}</p>
+            </div>
+          </div>
+
+          <div class="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-inner">
+            <div class="flex items-center justify-between">
+              <h4 class="text-lg font-semibold text-white">Temporada actual</h4>
+              <span class="rounded-full bg-purple-500/20 px-3 py-1 text-xs font-semibold text-purple-100">{todosEps.length} episodios</span>
+            </div>
+            <div class="mt-4 space-y-3 max-h-[520px] overflow-y-auto pr-2">
+              {todosEps.map((item, i) => (
+                <a
+                  href={`/serie/${slug}/${item.id}`}
+                  class={`group flex items-center gap-3 rounded-2xl border border-transparent px-3 py-3 transition duration-200 ${Number(episodio) === item.id ? 'bg-purple-600/30 border-purple-400/50' : 'hover:bg-white/5 border-white/5'}`}
+                >
+                  <span class={`flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold ${Number(episodio) === item.id ? 'bg-purple-600 text-white' : 'bg-white/10 text-gray-300 group-hover:bg-white/20'}`}>
+                    {i + 1}
+                  </span>
+                  <div class="flex-1">
+                    <p class="text-sm font-semibold text-white group-hover:text-purple-100">{item.titulo}</p>
+                    <p class="text-xs text-gray-400">{item.idioma}</p>
+                  </div>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke-width="1.5"
+                    stroke="currentColor"
+                    class="h-5 w-5 text-gray-400 opacity-0 transition group-hover:opacity-100"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m9 5 7 7-7 7" />
+                  </svg>
+                </a>
+              ))}
+            </div>
+          </div>
+        </aside>
+      </div>
     </div>
-
-    <!-- Columna lateral -->
-    <aside class="space-y-8">
-      <div>
-        <h4 class="font-bold mb-2">SIGUIENTE EPISODIO</h4>
-        {nextEp ? (
-          <a href={`/serie/${slug}/${nextEp.id}`} class="flex items-center space-x-2 hover:underline">
-            <img src={nextEp.imagen_preview} alt={nextEp.titulo} class="w-20 h-12 object-cover rounded" />
-            <div>
-              <p>{nextEp.titulo}</p>
-              <p class="text-gray-400 text-sm">{nextEp.idioma}</p>
-            </div>
-          </a>
-        ) : (
-          <p class="text-gray-500">Este es el último episodio.</p>
-        )}
-      </div>
-      <div>
-        <h4 class="font-bold mb-2">EPISODIO ANTERIOR</h4>
-        {prevEp ? (
-          <a href={`/serie/${slug}/${prevEp.id}`} class="flex items-center space-x-2 hover:underline">
-            <img src={prevEp.imagen_preview} alt={prevEp.titulo} class="w-20 h-12 object-cover rounded" />
-            <div>
-              <p>{prevEp.titulo}</p>
-              <p class="text-gray-400 text-sm">{prevEp.idioma}</p>
-            </div>
-          </a>
-        ) : (
-          <p class="text-gray-500">Este es el primer episodio.</p>
-        )}
-      </div>
-      <a
-        href={`/serie/${slug}`}
-        class="block w-full text-center border border-white py-2 rounded hover:bg-white hover:text-black transition"
-      >
-        VER MÁS EPISODIOS
-      </a>
-    </aside>
   </section>
 
   <!-- Carga Hls.js desde CDN -->


### PR DESCRIPTION
## Summary
- Actualiza la página de episodio con un layout más envolvente, gradientes y tarjetas de metadata para resaltar el contenido.
- Incorpora navegación y acciones con tarjetas estilizadas para episodios anterior/siguiente y acceso a más capítulos.
- Mejora la columna lateral con ficha de serie y lista desplazable de episodios de la temporada.

## Testing
- No se ejecutaron pruebas automatizadas (el servidor requiere conexión a la base de datos remota que no está disponible en este entorno).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5fc7f7648331a98e15a10771661b)