### PR TITLE
Improve episode section visuals

### DIFF
--- a/src/pages/serie/[slug].astro
+++ b/src/pages/serie/[slug].astro
@@ -245,7 +245,7 @@ if (usuarioId) {
             episodios.map(ep => (
               <a
                 href={`/serie/${slug}/${ep.id}`}
-                class="group relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-b from-[#12121b] to-[#0b0b13] shadow-lg transition duration-300 hover:-translate-y-1 hover:border-pink-500/50 hover:shadow-pink-500/20"
+                class="group relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-b from-[#12121b] to-[#0b0b13] ring-1 ring-white/5 shadow-lg transition duration-300 hover:-translate-y-1 hover:border-pink-500/50 hover:shadow-pink-500/20"
               >
                 <div class="aspect-video relative">
                   <img
@@ -254,19 +254,37 @@ if (usuarioId) {
                     class="h-full w-full object-cover"
                     onerror="this.src='/avatar.jpeg'"
                   />
-                  <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+                  <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
                   <div class="absolute left-3 top-3 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white backdrop-blur">
                     {ep.idioma}
                   </div>
+                  <div class="absolute right-3 bottom-3 rounded-full bg-black/60 px-3 py-1 text-xs font-semibold text-white backdrop-blur ring-1 ring-white/10">
+                    {ep.duracion} min
+                  </div>
+                  <div class="absolute inset-0 flex items-center justify-center opacity-0 transition duration-200 group-hover:opacity-100">
+                    <div class="flex items-center gap-2 rounded-full bg-black/60 px-3 py-1 text-sm font-semibold text-pink-200 backdrop-blur ring-1 ring-white/10">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" class="h-4 w-4" fill="currentColor">
+                        <path d="M73 39c-14.8-9.1-33.4-9.4-48.5-.7S0 60.7 0 77.5V434.5c0 16.8 9.1 32.3 24.5 39.2s33.7 6.4 48.5-.7l256-128c16.3-8.1 26.5-24.9 26.5-43s-10.2-34.9-26.5-43L73 39z" />
+                      </svg>
+                      <span>Ver ahora</span>
+                    </div>
+                  </div>
                 </div>
-                <div class="space-y-2 p-4">
-                  <h4 class="text-lg font-semibold text-white transition-colors group-hover:text-pink-300">
-                    {ep.titulo}
-                  </h4>
-                  <div class="flex items-center gap-2 text-sm text-white/60">
-                    <span class="rounded-full bg-white/10 px-3 py-1">{ep.duracion} min</span>
-                    <span class="h-1 w-1 rounded-full bg-white/30" aria-hidden="true" />
-                    <span>Episodio #{ep.id}</span>
+                <div class="space-y-3 p-4">
+                  <div class="flex items-start justify-between gap-2">
+                    <h4 class="text-lg font-semibold text-white transition-colors group-hover:text-pink-300">
+                      {ep.titulo}
+                    </h4>
+                    <span class="rounded-full bg-pink-600/20 px-3 py-1 text-xs font-semibold text-pink-200 ring-1 ring-pink-500/40">
+                      Ep #{ep.id}
+                    </span>
+                  </div>
+                  <div class="flex items-center justify-between text-sm text-white/70">
+                    <span class="flex items-center gap-2">
+                      <span class="h-2 w-2 rounded-full bg-pink-400" aria-hidden="true" />
+                      Listo para reproducir
+                    </span>
+                    <span class="text-white/60">{ep.idioma}</span>
                   </div>
                 </div>
               </a>
@@ -369,18 +387,32 @@ if (usuarioId) {
         if (nuevos.length > 0) {
           nuevos.forEach(ep => {
             html +=
-              '<a href="/serie/' + slug + '/' + ep.id + '" class="group relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-b from-[#12121b] to-[#0b0b13] shadow-lg transition duration-300 hover:-translate-y-1 hover:border-pink-500/50 hover:shadow-pink-500/20">' +
+              '<a href="/serie/' + slug + '/' + ep.id + '" class="group relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-b from-[#12121b] to-[#0b0b13] ring-1 ring-white/5 shadow-lg transition duration-300 hover:-translate-y-1 hover:border-pink-500/50 hover:shadow-pink-500/20">' +
                 '<div class="aspect-video relative">' +
                   '<img src="' + (ep.imagen_preview || '/avatar.jpeg') + '" alt="' + ep.titulo + '" class="h-full w-full object-cover" onerror="this.src=\'/avatar.jpeg\'" />' +
-                  '<div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent"></div>' +
+                  '<div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>' +
                   '<div class="absolute left-3 top-3 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white backdrop-blur">' + ep.idioma + '</div>' +
+                  '<div class="absolute right-3 bottom-3 rounded-full bg-black/60 px-3 py-1 text-xs font-semibold text-white backdrop-blur ring-1 ring-white/10">' + ep.duracion + ' min</div>' +
+                  '<div class="absolute inset-0 flex items-center justify-center opacity-0 transition duration-200 group-hover:opacity-100">' +
+                    '<div class="flex items-center gap-2 rounded-full bg-black/60 px-3 py-1 text-sm font-semibold text-pink-200 backdrop-blur ring-1 ring-white/10">' +
+                      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" class="h-4 w-4" fill="currentColor">' +
+                        '<path d="M73 39c-14.8-9.1-33.4-9.4-48.5-.7S0 60.7 0 77.5V434.5c0 16.8 9.1 32.3 24.5 39.2s33.7 6.4 48.5-.7l256-128c16.3-8.1 26.5-24.9 26.5-43s-10.2-34.9-26.5-43L73 39z" />' +
+                      '</svg>' +
+                      '<span>Ver ahora</span>' +
+                    '</div>' +
+                  '</div>' +
                 '</div>' +
-                '<div class="space-y-2 p-4">' +
-                  '<h4 class="text-lg font-semibold text-white transition-colors group-hover:text-pink-300">' + ep.titulo + '</h4>' +
-                  '<div class="flex items-center gap-2 text-sm text-white/60">' +
-                    '<span class="rounded-full bg-white/10 px-3 py-1">' + ep.duracion + ' min</span>' +
-                    '<span class="h-1 w-1 rounded-full bg-white/30" aria-hidden="true"></span>' +
-                    '<span>Episodio #' + ep.id + '</span>' +
+                '<div class="space-y-3 p-4">' +
+                  '<div class="flex items-start justify-between gap-2">' +
+                    '<h4 class="text-lg font-semibold text-white transition-colors group-hover:text-pink-300">' + ep.titulo + '</h4>' +
+                    '<span class="rounded-full bg-pink-600/20 px-3 py-1 text-xs font-semibold text-pink-200 ring-1 ring-pink-500/40">Ep #' + ep.id + '</span>' +
+                  '</div>' +
+                  '<div class="flex items-center justify-between text-sm text-white/70">' +
+                    '<span class="flex items-center gap-2">' +
+                      '<span class="h-2 w-2 rounded-full bg-pink-400" aria-hidden="true"></span>' +
+                      'Listo para reproducir' +
+                    '</span>' +
+                    '<span class="text-white/60">' + ep.idioma + '</span>' +
                   '</div>' +
                 '</div>' +
               '</a>';


### PR DESCRIPTION
## Summary
- Refine the episode card layout with gradient overlay, ring accent, and play call-to-action
- Highlight duration and episode number with clearer badges while keeping existing format
- Mirror the updated styling in the dynamic season change rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d636f58d483319c5af47f36d232bf)