### PR TITLE
Improve episode card styling

### DIFF
--- a/src/pages/serie/[slug].astro
+++ b/src/pages/serie/[slug].astro
@@ -245,8 +245,9 @@ if (usuarioId) {
             episodios.map(ep => (
               <a
                 href={`/serie/${slug}/${ep.id}`}
-                class="group relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-b from-[#12121b] to-[#0b0b13] ring-1 ring-white/5 shadow-lg transition duration-300 hover:-translate-y-1 hover:border-pink-500/50 hover:shadow-pink-500/20"
+                class="group relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-b from-[#12121b] via-[#11101c] to-[#0b0b13] ring-1 ring-white/5 shadow-lg transition duration-300 hover:-translate-y-1 hover:border-pink-500/50 hover:shadow-pink-500/20"
               >
+                <div class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-pink-400/60 to-transparent opacity-60 transition-opacity duration-300 group-hover:opacity-90" />
                 <div class="aspect-video relative">
                   <img
                     src={ep.imagen_preview || '/avatar.jpeg'}
@@ -254,7 +255,7 @@ if (usuarioId) {
                     class="h-full w-full object-cover"
                     onerror="this.src='/avatar.jpeg'"
                   />
-                  <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+                  <div class="absolute inset-0 bg-gradient-to-t from-black/85 via-black/35 to-transparent" />
                   <div class="absolute left-3 top-3 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white backdrop-blur">
                     {ep.idioma}
                   </div>
@@ -262,7 +263,7 @@ if (usuarioId) {
                     {ep.duracion} min
                   </div>
                   <div class="absolute inset-0 flex items-center justify-center opacity-0 transition duration-200 group-hover:opacity-100">
-                    <div class="flex items-center gap-2 rounded-full bg-black/60 px-3 py-1 text-sm font-semibold text-pink-200 backdrop-blur ring-1 ring-white/10">
+                    <div class="flex items-center gap-2 rounded-full bg-black/70 px-3 py-1 text-sm font-semibold text-pink-200 backdrop-blur ring-1 ring-white/10">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" class="h-4 w-4" fill="currentColor">
                         <path d="M73 39c-14.8-9.1-33.4-9.4-48.5-.7S0 60.7 0 77.5V434.5c0 16.8 9.1 32.3 24.5 39.2s33.7 6.4 48.5-.7l256-128c16.3-8.1 26.5-24.9 26.5-43s-10.2-34.9-26.5-43L73 39z" />
                       </svg>
@@ -279,13 +280,21 @@ if (usuarioId) {
                       Ep #{ep.id}
                     </span>
                   </div>
-                  <div class="flex items-center justify-between text-sm text-white/70">
-                    <span class="flex items-center gap-2">
-                      <span class="h-2 w-2 rounded-full bg-pink-400" aria-hidden="true" />
+                  <div class="flex flex-wrap items-center gap-2 text-xs text-white/70">
+                    <span class="inline-flex items-center gap-1 rounded-full bg-white/5 px-2 py-1 ring-1 ring-white/10">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3.5 w-3.5 text-pink-300">
+                        <path d="M4.5 4.5A2.25 2.25 0 0 1 6.75 2.25h10.5A2.25 2.25 0 0 1 19.5 4.5v15.75a.75.75 0 0 1-1.21.586L12 16.06l-6.29 4.776a.75.75 0 0 1-1.21-.586z" />
+                      </svg>
                       Listo para reproducir
                     </span>
-                    <span class="text-white/60">{ep.idioma}</span>
+                    <span class="inline-flex items-center gap-1 rounded-full bg-white/5 px-2 py-1 ring-1 ring-white/10">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3.5 w-3.5 text-blue-200">
+                        <path fill-rule="evenodd" d="M12 2.25a9.75 9.75 0 1 0 0 19.5 9.75 9.75 0 0 0 0-19.5Zm-6 9.75a6 6 0 0 1 6-6 .75.75 0 0 1 0 1.5 4.5 4.5 0 1 0 4.5 4.5.75.75 0 0 1 1.5 0 6 6 0 0 1-12 0Z" clip-rule="evenodd" />
+                      </svg>
+                      {ep.duracion} min
+                    </span>
                   </div>
+                  <div class="h-1 rounded-full bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 opacity-50 transition-opacity duration-300 group-hover:opacity-100" />
                 </div>
               </a>
             ))


### PR DESCRIPTION
## Summary
- Add subtle gradient accents to episode cards for a refreshed look while keeping existing layout
- Introduce compact meta badges to highlight playback readiness and duration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d65315af48331a506fcfaff0358f2)