### PR TITLE
Improve episode page styling

### DIFF
--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -62,11 +62,11 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
 ---
 
 <Layout class="bg-black text-white">
-  <section class="mt-30 max-w-5xl mx-auto px-8 py-10 grid lg:grid-cols-3 gap-8">
+  <section class="mt-30 max-w-5xl mx-auto px-8 py-10 grid lg:grid-cols-3 gap-8 bg-gradient-to-b from-white/5 via-white/5 to-transparent rounded-3xl shadow-2xl shadow-purple-500/10 border border-white/10">
     <!-- Columna principal -->
     <div class="lg:col-span-2 space-y-6">
       <!-- Video player -->
-      <div class="aspect-video bg-black rounded overflow-hidden">
+      <div class="aspect-video bg-black/70 rounded-2xl overflow-hidden ring-1 ring-white/10 shadow-xl shadow-purple-500/20 backdrop-blur">
         <video
           id="video-player"
           controls
@@ -79,52 +79,78 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
       </div>
 
       <!-- Encabezado de episodio -->
-      <div class="space-y-2">
-        <h2 class="text-2xl font-bold">{ep.titulo}</h2>
-        <p class="text-gray-400">
-          {ep.idioma} • {ep.duracion} min • Lanzado el{' '}
-          {new Date(ep.fecha_estreno).toLocaleDateString()}
-        </p>
+      <div class="space-y-3 bg-white/5 border border-white/10 rounded-2xl px-4 py-3 shadow-lg shadow-purple-500/10 backdrop-blur">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h2 class="text-2xl font-bold leading-tight">{ep.titulo}</h2>
+            <p class="text-gray-300 text-sm">
+              {new Date(ep.fecha_estreno).toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' })}
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-2 text-xs font-semibold">
+            <span class="inline-flex items-center gap-1 rounded-full bg-purple-500/15 text-purple-100 px-3 py-1 border border-purple-400/30">
+              <span class="h-2 w-2 rounded-full bg-purple-300"></span>
+              {ep.idioma}
+            </span>
+            <span class="inline-flex items-center gap-1 rounded-full bg-white/10 text-white px-3 py-1 border border-white/15">
+              ⏱ {ep.duracion} min
+            </span>
+          </div>
+        </div>
         <div
           id="reactions"
           data-serie-id={serieId}
           data-user-id={usuarioId}
           data-user-reaction={userReaction}
-          class="flex items-center space-x-4"
+          class="flex items-center space-x-4 pt-1"
         >
           <!-- BOTONES LIKE/DISLIKE -->
         </div>
       </div>
 
       <!-- Descripción -->
-      <p class="text-gray-200 leading-relaxed">{serie.descripcion}</p>
+      <p class="text-gray-200 leading-relaxed bg-white/5 border border-white/10 rounded-2xl px-4 py-3 shadow-lg shadow-purple-500/10 backdrop-blur">
+        {serie.descripcion}
+      </p>
     </div>
 
     <!-- Columna lateral -->
-    <aside class="space-y-8">
-      <div>
-        <h4 class="font-bold mb-2">SIGUIENTE EPISODIO</h4>
+    <aside class="space-y-6">
+      <div class="bg-white/5 border border-white/10 rounded-2xl p-4 shadow-lg shadow-purple-500/10 backdrop-blur">
+        <div class="flex items-center justify-between mb-3">
+          <h4 class="font-bold">SIGUIENTE EPISODIO</h4>
+          <span class="text-xs px-2 py-1 rounded-full bg-green-500/15 text-green-100 border border-green-400/20">Auto</span>
+        </div>
         {nextEp ? (
-          <a href={`/serie/${slug}/${nextEp.id}`} class="flex items-center space-x-2 hover:underline">
-            <img src={nextEp.imagen_preview} alt={nextEp.titulo} class="w-20 h-12 object-cover rounded" />
-            <div>
+          <a href={`/serie/${slug}/${nextEp.id}`} class="flex items-center gap-3 group">
+            <img src={nextEp.imagen_preview} alt={nextEp.titulo} class="w-20 h-14 object-cover rounded-lg ring-1 ring-white/10" />
+            <div class="flex-1">
               <p>{nextEp.titulo}</p>
-              <p class="text-gray-400 text-sm">{nextEp.idioma}</p>
+              <p class="text-gray-400 text-sm flex items-center gap-2">
+                <span class="h-1.5 w-1.5 rounded-full bg-purple-300"></span>{nextEp.idioma}
+              </p>
             </div>
+            <span class="text-sm text-purple-200 opacity-0 group-hover:opacity-100 transition">→</span>
           </a>
         ) : (
           <p class="text-gray-500">Este es el último episodio.</p>
         )}
       </div>
-      <div>
-        <h4 class="font-bold mb-2">EPISODIO ANTERIOR</h4>
+      <div class="bg-white/5 border border-white/10 rounded-2xl p-4 shadow-lg shadow-purple-500/10 backdrop-blur">
+        <div class="flex items-center justify-between mb-3">
+          <h4 class="font-bold">EPISODIO ANTERIOR</h4>
+          <span class="text-xs px-2 py-1 rounded-full bg-blue-500/15 text-blue-100 border border-blue-400/20">Replay</span>
+        </div>
         {prevEp ? (
-          <a href={`/serie/${slug}/${prevEp.id}`} class="flex items-center space-x-2 hover:underline">
-            <img src={prevEp.imagen_preview} alt={prevEp.titulo} class="w-20 h-12 object-cover rounded" />
-            <div>
+          <a href={`/serie/${slug}/${prevEp.id}`} class="flex items-center gap-3 group">
+            <img src={prevEp.imagen_preview} alt={prevEp.titulo} class="w-20 h-14 object-cover rounded-lg ring-1 ring-white/10" />
+            <div class="flex-1">
               <p>{prevEp.titulo}</p>
-              <p class="text-gray-400 text-sm">{prevEp.idioma}</p>
+              <p class="text-gray-400 text-sm flex items-center gap-2">
+                <span class="h-1.5 w-1.5 rounded-full bg-purple-300"></span>{prevEp.idioma}
+              </p>
             </div>
+            <span class="text-sm text-purple-200 opacity-0 group-hover:opacity-100 transition">←</span>
           </a>
         ) : (
           <p class="text-gray-500">Este es el primer episodio.</p>
@@ -132,7 +158,7 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
       </div>
       <a
         href={`/serie/${slug}`}
-        class="block w-full text-center border border-white py-2 rounded hover:bg-white hover:text-black transition"
+        class="block w-full text-center border border-white/20 bg-white/10 py-3 rounded-2xl hover:bg-white hover:text-black transition font-semibold shadow-md shadow-purple-500/20"
       >
         VER MÁS EPISODIOS
       </a>


### PR DESCRIPTION
## Summary
- Refresh the episode detail layout with soft gradients, glassy cards, and pill badges to highlight metadata
- Enhance next/previous episode cards with hover cues and clearer labels while keeping layout structure
- Update call-to-action styling for navigating back to the series list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d673613348331bc62371b712258dd)