### PR TITLE
Remove hero stats sections from directory and explore pages

### DIFF
--- a/src/pages/directorio.astro
+++ b/src/pages/directorio.astro
@@ -30,44 +30,6 @@ const series = Array.isArray(allSeries) ? allSeries : [];
 
 <Layout>
   <section class="container mx-auto px-4 py-12 space-y-10">
-    <div class="relative overflow-hidden rounded-2xl bg-gradient-to-r from-purple-900/80 via-indigo-900/70 to-slate-900/80 p-8 border border-white/5 shadow-2xl">
-      <div class="absolute inset-0 opacity-30 blur-3xl bg-[radial-gradient(circle_at_top,_rgba(167,139,250,0.4),_transparent_40%),_radial-gradient(circle_at_bottom,_rgba(56,189,248,0.35),_transparent_45%)]"></div>
-      <div class="relative grid lg:grid-cols-3 gap-6 items-center">
-        <div class="lg:col-span-2 space-y-4">
-          <p class="text-sm uppercase tracking-[0.3em] text-purple-200/70">Directorio</p>
-          <h1 class="text-4xl sm:text-5xl font-extrabold text-white leading-tight">Descubre todas las series disponibles</h1>
-          <p class="text-gray-200/80 text-lg max-w-2xl">Explora el catálogo completo organizado con detalles rápidos de temporadas, episodios y una vista previa mejorada.</p>
-          <div class="flex flex-wrap gap-3 text-sm text-white/80">
-            <span class="px-4 py-2 rounded-full bg-white/5 border border-white/10 backdrop-blur">{series.length} series disponibles</span>
-            <span class="px-4 py-2 rounded-full bg-white/5 border border-white/10 backdrop-blur flex items-center gap-2">
-              <span class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span> Catálogo siempre actualizado
-            </span>
-          </div>
-        </div>
-        <div class="grid grid-cols-2 gap-3 text-center">
-          <div class="rounded-xl bg-black/40 border border-white/10 p-4 shadow-lg">
-            <p class="text-sm text-gray-300">Promedio de temporadas</p>
-            <p class="text-3xl font-bold text-white">{Math.round(series.reduce((acc, s) => acc + s.temporada_count, 0) / (series.length || 1))}</p>
-          </div>
-          <div class="rounded-xl bg-black/40 border border-white/10 p-4 shadow-lg">
-            <p class="text-sm text-gray-300">Total episodios</p>
-            <p class="text-3xl font-bold text-white">{series.reduce((acc, s) => acc + s.episodio_count, 0)}</p>
-          </div>
-          <div class="col-span-2 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-500 p-[1px] shadow-lg">
-            <div class="rounded-[11px] bg-slate-900/80 p-4 h-full flex items-center justify-between">
-              <div class="text-left">
-                <p class="text-sm text-purple-100">Consejo</p>
-                <p class="text-lg font-semibold text-white">Usa las tarjetas para obtener detalles al instante</p>
-              </div>
-              <svg class="w-10 h-10 text-purple-200" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2" />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {series.map((serie: Serie) => (
         <a

--- a/src/pages/explorar.astro
+++ b/src/pages/explorar.astro
@@ -54,48 +54,6 @@ const lista = Array.isArray(series) ? series : [];
 
 <Layout>
   <section class="mt-24 px-4 pb-12 space-y-10">
-    <div class="relative overflow-hidden rounded-2xl border border-white/5 bg-gradient-to-r from-indigo-900/80 via-purple-900/70 to-slate-900/80 p-8 shadow-2xl">
-      <div class="absolute inset-0 opacity-40 blur-3xl bg-[radial-gradient(circle_at_20%_30%,_rgba(129,140,248,0.35),_transparent_45%),_radial-gradient(circle_at_80%_40%,_rgba(248,113,113,0.35),_transparent_45%)]"></div>
-      <div class="relative grid lg:grid-cols-3 gap-8 items-center">
-        <div class="lg:col-span-2 space-y-4">
-          <p class="text-sm uppercase tracking-[0.35em] text-indigo-100/80">Explorar</p>
-          <h1 class="text-4xl sm:text-5xl font-extrabold text-white leading-tight">Explora las series por {tituloOrden.toLowerCase()}</h1>
-          <p class="text-lg text-indigo-50/90 max-w-2xl">Intercambia el orden fácilmente y descubre nuevas historias con una rejilla enfocada en mostrar la información clave de cada anime.</p>
-          <div class="flex flex-wrap gap-2">
-            {['popular', 'reciente', 'antiguo'].map(opcion => (
-              <button
-                data-filtro={opcion}
-                class={`orden-btn px-4 py-2 rounded-full border transition-all duration-200 ${orden === opcion ? 'bg-white text-slate-900 font-semibold border-white' : 'bg-white/10 text-white border-white/20 hover:border-white/60'}`}
-              >
-                {opcion === 'popular' ? 'Popularidad' : opcion === 'reciente' ? 'Lo más reciente' : 'Más antiguas'}
-              </button>
-            ))}
-          </div>
-        </div>
-        <div class="grid grid-cols-2 gap-3 text-center">
-          <div class="rounded-xl bg-black/40 border border-white/10 p-4 shadow-lg">
-            <p class="text-sm text-gray-300">Total de series</p>
-            <p class="text-3xl font-bold text-white">{lista.length}</p>
-          </div>
-          <div class="rounded-xl bg-black/40 border border-white/10 p-4 shadow-lg">
-            <p class="text-sm text-gray-300">Episodios promedio</p>
-            <p class="text-3xl font-bold text-white">{Math.round(lista.reduce((acc, s) => acc + s.episodio_count, 0) / (lista.length || 1))}</p>
-          </div>
-          <div class="col-span-2 rounded-xl bg-white/10 border border-white/15 p-4 flex items-center gap-3 text-left">
-            <div class="w-12 h-12 rounded-full bg-purple-500/30 flex items-center justify-center text-white">
-              <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
-              </svg>
-            </div>
-            <div>
-              <p class="text-sm text-purple-100">Tip rápido</p>
-              <p class="text-base text-white">Elige un filtro para reorganizar la rejilla al instante.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {lista.map(serie => (
         <a href={`/serie/${serie.slug}`} class="group relative block rounded-2xl overflow-hidden bg-gradient-to-b from-slate-950/80 to-black/80 border border-white/5 shadow-xl transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl hover:border-indigo-400/40">


### PR DESCRIPTION
## Summary
- remove introductory hero metrics block from Directorio page to streamline view
- remove hero stats and tips section from Explorar page leaving grid focus

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d68540e4883319ebfa71eef6e1c6a)