### PR TITLE
Enable live search while typing

### DIFF
--- a/src/pages/buscar.astro
+++ b/src/pages/buscar.astro
@@ -430,10 +430,26 @@ if (q) {
       }
     }, 300);
 
-    searchInput?.addEventListener('input', event => handleQueryChange(event.target.value));
+    const runLiveSearch = () => handleQueryChange(searchInput?.value || '');
+
+    searchInput?.addEventListener('input', event => {
+      const target = event.currentTarget;
+      runLiveSearch();
+
+      if (target instanceof HTMLInputElement) {
+        suggestionsContainer?.classList.remove('hidden');
+      }
+    });
+
+    searchInput?.addEventListener('focus', () => {
+      if (searchInput.value.trim()) {
+        runLiveSearch();
+      }
+    });
+
     form?.addEventListener('submit', event => {
       event.preventDefault();
-      handleQueryChange(searchInput?.value || '');
+      runLiveSearch();
     });
 
     render(initialResults, currentQuery);


### PR DESCRIPTION
## Summary
- trigger search updates on input and focus without needing the submit button
- ensure suggestions panel becomes visible as the user types

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951bfbd37088331a633548a962bd1c3)