### PR TITLE
Fix carousel scrolling and episode numbering display

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -540,7 +540,8 @@ const heroThumbs = heroSlides.length ? heroSlides : featuredShowcase;
       if (!firstCard) return track.clientWidth;
 
       const styles = getComputedStyle(track);
-      const gap = parseFloat(styles.columnGap || styles.gap || '0');
+      const parsedGap = parseFloat(styles.columnGap || styles.gap || '0');
+      const gap = Number.isFinite(parsedGap) ? parsedGap : 0;
       return firstCard.getBoundingClientRect().width + gap;
     };
 
@@ -562,6 +563,7 @@ const heroThumbs = heroSlides.length ? heroSlides : featuredShowcase;
     });
 
     track.addEventListener('scroll', () => updateButtons());
+    window.addEventListener('resize', () => updateButtons());
 
     const observer = new IntersectionObserver(
       entries => {

--- a/src/pages/serie/[slug].astro
+++ b/src/pages/serie/[slug].astro
@@ -24,6 +24,7 @@ interface Temporada extends RowDataPacket {
 
 interface Episodio extends RowDataPacket {
   id: number;
+  numero_episodio: number;
   titulo: string;
   imagen_preview: string;
   duracion: number;
@@ -266,7 +267,7 @@ if (usuarioId) {
                   <div class="flex items-center gap-2 text-sm text-white/60">
                     <span class="rounded-full bg-white/10 px-3 py-1">{ep.duracion} min</span>
                     <span class="h-1 w-1 rounded-full bg-white/30" aria-hidden="true" />
-                    <span>Episodio #{ep.id}</span>
+                    <span>Episodio #{ep.numero_episodio ?? ep.id}</span>
                   </div>
                 </div>
               </a>
@@ -380,7 +381,7 @@ if (usuarioId) {
                   '<div class="flex items-center gap-2 text-sm text-white/60">' +
                     '<span class="rounded-full bg-white/10 px-3 py-1">' + ep.duracion + ' min</span>' +
                     '<span class="h-1 w-1 rounded-full bg-white/30" aria-hidden="true"></span>' +
-                    '<span>Episodio #' + ep.id + '</span>' +
+                    '<span>Episodio #' + (ep.numero_episodio ?? ep.id) + '</span>' +
                   '</div>' +
                 '</div>' +
               '</a>';


### PR DESCRIPTION
## Summary
- make the featured carousel buttons more reliable by guarding gap calculations and refreshing state on resize
- show season-specific episode numbers instead of database IDs on series pages and episode loads

## Testing
- npm run build *(fails: NoAdapterInstalled and route collision warnings in existing setup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951cc126c208331821ffd31dd73a9ca)