### PR TITLE
Add MKV playback support

### DIFF
--- a/src/pages/player/[episodio].html.ts
+++ b/src/pages/player/[episodio].html.ts
@@ -29,7 +29,7 @@ export const GET: APIRoute = async ({ params, request }) => {
     const path = new URL(raw).pathname;
 
     // quitamos el archivo final y normalizamos el host
-    const withoutFile = path.replace(/\/(\d{1,2})(\.mp4|\.m3u8)?$/, '');
+    const withoutFile = path.replace(/\/(\d{1,2})(\.mp4|\.m3u8|\.mkv)?$/, '');
     return `https://videos.clawn.cat${withoutFile.replace(/\/$/, '')}`;
   };
 
@@ -108,6 +108,11 @@ export const GET: APIRoute = async ({ params, request }) => {
     const mp4Candidates = [
       `${basePath}/${episodioStr}.mp4`,
       `${basePath}/${episodio}.mp4`
+    ];
+
+    const mkvCandidates = [
+      `${basePath}/${episodioStr}.mkv`,
+      `${basePath}/${episodio}.mkv`
     ];
 
     const subtitlesCandidates = [
@@ -217,11 +222,14 @@ export const GET: APIRoute = async ({ params, request }) => {
     const initializeSources = async () => {
       const hlsSource = await pickFirstReachable(hlsCandidates);
       const mp4Source = await pickFirstReachable(mp4Candidates);
+      const mkvSource = await pickFirstReachable(mkvCandidates);
 
       if (hlsSource) {
         player.src({ src: hlsSource, type: 'application/x-mpegURL' });
-      } else if (mp4Source) {
+      } else if (mp4Source && videoElement.canPlayType('video/mp4')) {
         player.src({ src: mp4Source, type: 'video/mp4' });
+      } else if (mkvSource && videoElement.canPlayType('video/x-matroska')) {
+        player.src({ src: mkvSource, type: 'video/x-matroska' });
       } else {
         alert('No se pudo cargar el video.');
       }
@@ -229,9 +237,14 @@ export const GET: APIRoute = async ({ params, request }) => {
       // fallback extra: si el HLS falla en reproducción, usar mp4
       player.on('error', () => {
         const current = player.currentSource();
-        if (current?.type === 'application/x-mpegURL' && mp4Source) {
-          player.src({ src: mp4Source, type: 'video/mp4' });
-          player.play().catch(() => {});
+        if (current?.type === 'application/x-mpegURL') {
+          if (mp4Source && videoElement.canPlayType('video/mp4')) {
+            player.src({ src: mp4Source, type: 'video/mp4' });
+            player.play().catch(() => {});
+          } else if (mkvSource && videoElement.canPlayType('video/x-matroska')) {
+            player.src({ src: mkvSource, type: 'video/x-matroska' });
+            player.play().catch(() => {});
+          }
         }
       });
     };

--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -195,29 +195,29 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
       const url = normalizeHost(rawUrl);
       const normalizeExt = (targetUrl) => targetUrl.split('.').pop().split('?')[0].toLowerCase();
 
-      const deriveMp4Candidates = (targetUrl) => {
+      const deriveFileCandidates = (targetUrl, extensions) => {
         try {
           const parsed = new URL(targetUrl);
-          const match = parsed.pathname.match(/\/(\d+)(?:\.m3u8|\.mp4)$/);
+          const match = parsed.pathname.match(/\/(\d+)(?:\.m3u8|\.mp4|\.mkv)$/);
 
           if (!match) return [];
 
           const episodioNumber = match[1];
-          const basePath = parsed.pathname.replace(/\/(\d+)(?:\.m3u8|\.mp4)$/, '');
+          const basePath = parsed.pathname.replace(/\/(\d+)(?:\.m3u8|\.mp4|\.mkv)$/, '');
           const padded = episodioNumber.padStart(2, '0');
 
-          return [
-            `${parsed.origin}${basePath}/${padded}.mp4`,
-            `${parsed.origin}${basePath}/${episodioNumber}.mp4`
-          ];
+          return extensions.flatMap((ext) => [
+            `${parsed.origin}${basePath}/${padded}.${ext}`,
+            `${parsed.origin}${basePath}/${episodioNumber}.${ext}`
+          ]);
         } catch (error) {
           console.error('No se pudo procesar la URL del video', error);
           return [];
         }
       };
 
-      const findWorkingMp4 = async (targetUrl) => {
-        const candidates = deriveMp4Candidates(targetUrl);
+      const findWorkingSource = async (targetUrl, extensions) => {
+        const candidates = deriveFileCandidates(targetUrl, extensions);
 
         for (const candidate of candidates) {
           try {
@@ -254,18 +254,38 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
           } else if (window.Hls && Hls.isSupported()) {
             attachHls(url);
           } else {
-            console.warn('HLS no soportado, intentando fallback MP4...');
-            const mp4Source = await findWorkingMp4(url);
+            console.warn('HLS no soportado, intentando fallback MP4/MKV...');
+            const mp4Source = await findWorkingSource(url, ['mp4']);
+            const mkvSource = await findWorkingSource(url, ['mkv']);
 
             if (mp4Source && video.canPlayType('video/mp4')) {
               video.src = mp4Source;
+            } else if (mkvSource && video.canPlayType('video/x-matroska')) {
+              video.src = mkvSource;
             } else {
-              console.error('No se pudo reproducir el stream HLS ni encontrar un MP4 disponible');
+              console.error('No se pudo reproducir el stream HLS ni encontrar un MP4/MKV disponible');
             }
           }
-        } else if (video.canPlayType('video/mp4')) {
+        } else if (ext === 'mp4' && video.canPlayType('video/mp4')) {
           // MP4 directo
           video.src = url;
+        } else if (ext === 'mkv' && video.canPlayType('video/x-matroska')) {
+          // MKV directo
+          video.src = url;
+        } else if (ext === 'mp4' || ext === 'mkv') {
+          // fallback intenta encontrar otra extensión compatible
+          const alternative = ext === 'mp4'
+            ? await findWorkingSource(url, ['mkv'])
+            : await findWorkingSource(url, ['mp4']);
+
+          const isMkvAlt = alternative?.toLowerCase().endsWith('.mkv');
+          const isMp4Alt = alternative?.toLowerCase().endsWith('.mp4');
+
+          if ((isMp4Alt && video.canPlayType('video/mp4')) || (isMkvAlt && video.canPlayType('video/x-matroska'))) {
+            video.src = alternative;
+          } else {
+            console.error('Formato de video no soportado:', ext);
+          }
         } else {
           console.error('Formato de video no soportado:', ext);
         }


### PR DESCRIPTION
## Summary
- extend player URL normalization and source selection to include MKV files alongside MP4 and HLS
- add MKV fallbacks when HLS or MP4 playback is unavailable in both player entry points

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959721761c08331a31fbbc5eb202eaa)