### PR TITLE
Add video proxy to resolve CORS playback

### DIFF
--- a/src/pages/api/proxy/video.ts
+++ b/src/pages/api/proxy/video.ts
@@ -1,0 +1,70 @@
+import type { APIRoute } from 'astro';
+
+const ALLOWED_HOSTS = new Set(['videos.clawn.cat']);
+
+const resolveTarget = (rawUrl: string) => {
+  try {
+    const target = new URL(rawUrl);
+    if (!ALLOWED_HOSTS.has(target.hostname)) return null;
+    return target;
+  } catch (error) {
+    console.error('URL de proxy inválida', error);
+    return null;
+  }
+};
+
+const forwardHeaders = (request: Request) => {
+  const headers = new Headers();
+  const range = request.headers.get('range');
+  const ifRange = request.headers.get('if-range');
+  const ifModifiedSince = request.headers.get('if-modified-since');
+
+  if (range) headers.set('range', range);
+  if (ifRange) headers.set('if-range', ifRange);
+  if (ifModifiedSince) headers.set('if-modified-since', ifModifiedSince);
+
+  return headers;
+};
+
+const buildProxiedResponse = (upstream: Response) => {
+  const headers = new Headers(upstream.headers);
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+  headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+};
+
+const handleProxy = async (request: Request, method: 'GET' | 'HEAD') => {
+  const targetParam = new URL(request.url).searchParams.get('url');
+
+  if (!targetParam) {
+    return new Response('Falta el parámetro url', { status: 400 });
+  }
+
+  const target = resolveTarget(targetParam);
+  if (!target) {
+    return new Response('Dominio no permitido', { status: 400 });
+  }
+
+  try {
+    const upstream = await fetch(target.toString(), {
+      method,
+      headers: forwardHeaders(request),
+    });
+
+    return buildProxiedResponse(upstream);
+  } catch (error) {
+    console.error('Error al solicitar el recurso externo', error);
+    return new Response('No se pudo obtener el recurso solicitado', { status: 502 });
+  }
+};
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request }) => handleProxy(request, 'GET');
+export const HEAD: APIRoute = async ({ request }) => handleProxy(request, 'HEAD');

--- a/src/pages/player/[episodio].html.ts
+++ b/src/pages/player/[episodio].html.ts
@@ -34,6 +34,7 @@ export const GET: APIRoute = async ({ params, request }) => {
   };
 
   const basePath = normalizeBasePath(ep.video_url);
+  const proxify = (url: string) => `/api/proxy/video?url=${encodeURIComponent(url)}`;
 
   const [historialRows] = await db.query(
     'SELECT progreso FROM historial WHERE usuario_id = ? AND episodio_id = ?',
@@ -110,27 +111,27 @@ export const GET: APIRoute = async ({ params, request }) => {
     const hlsCandidates = [
       `${basePath}/${episodioStr}.m3u8`,
       `${basePath}/${episodio}.m3u8`
-    ];
+    ].map(proxify);
 
     const mp4Candidates = [
       `${basePath}/${episodioStr}.mp4`,
       `${basePath}/${episodio}.mp4`
-    ];
+    ].map(proxify);
 
     const mkvCandidates = [
       `${basePath}/${episodioStr}.mkv`,
       `${basePath}/${episodio}.mkv`
-    ];
+    ].map(proxify);
 
     const subtitlesCandidates = [
       `${basePath}/${episodioStr}_subtitles_latam.vtt`,
       `${basePath}/${episodio}_subtitles_latam.vtt`,
-    ];
+    ].map(proxify);
 
     const altAudioCandidates = [
       `${basePath}/${episodioStr}_audio_jpn.opus`,
       `${basePath}/${episodio}_audio_jpn.opus`
-    ];
+    ].map(proxify);
 
     const pickFirstReachable = async (urls) => {
       for (const url of urls) {

--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -174,6 +174,8 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
     const video = document.getElementById('video-player');
     const rawUrl = video.dataset.videoUrl;
 
+    const proxify = (target) => `/api/proxy/video?url=${encodeURIComponent(target)}`;
+
     const normalizeHost = (targetUrl) => {
       try {
         const parsed = new URL(targetUrl);
@@ -233,7 +235,7 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
         };
 
         const unique = Array.from(new Set(baseCandidates.filter(Boolean)));
-        return unique.filter(canPlay);
+        return unique.filter(canPlay).map(proxify);
       };
 
       const attachHls = (hlsUrl) => {


### PR DESCRIPTION
## Summary
- add a proxy API endpoint that forwards allowed video hosts with permissive CORS headers
- route episode video, subtitles, and alternate audio sources through the proxy to avoid browser CORS blocks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959a414f9308331bdb2d8c3ae425db3)