### PR TITLE
Customize episode player layout and controls

### DIFF
--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -75,12 +75,11 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
 ---
 
 <Layout class="bg-black text-white">
-  <section class="mt-30 max-w-6xl mx-auto px-6 sm:px-8 py-10 space-y-8">
-    <div class="player-shell relative rounded-3xl overflow-hidden border border-white/10 shadow-2xl shadow-purple-500/30 bg-black">
+  <section class="mt-12 max-w-6xl mx-auto px-6 sm:px-8 py-10 space-y-8">
+    <div class="player-shell relative rounded-3xl overflow-hidden border border-white/10 shadow-2xl shadow-purple-500/30 bg-gradient-to-b from-purple-950/50 via-black to-black">
       <div class="aspect-video">
         <video
           id="video-player"
-          controls
           playsinline
           crossorigin="anonymous"
           poster={ep.imagen_preview}
@@ -88,10 +87,50 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
           data-user-id={usuarioId}
           data-episodio-id={episodio}
           data-progress={progresoGuardado}
-          class="w-full h-full object-contain bg-black"
+          class="w-full h-full object-contain bg-black focus:outline-none"
         >
           Tu navegador no soporta la reproduccin de video.
         </video>
+        <div class="player-overlay pointer-events-none"></div>
+        <div class="player-ui">
+          <div class="player-top">
+            <span class="pill">HD</span>
+            <span class="pill">Sub</span>
+          </div>
+          <div class="player-bottom">
+            <div class="player-controls">
+              <div class="controls-left">
+                <button id="play-toggle" class="control-btn" aria-label="Reproducir o pausar">
+                  ▶
+                </button>
+                <button id="mute-toggle" class="control-btn" aria-label="Silenciar o activar sonido">
+                  🔊
+                </button>
+                <input id="volume-slider" type="range" min="0" max="1" step="0.01" value="1" class="volume-slider" aria-label="Volumen" />
+                <div class="time-display">
+                  <span id="current-time">0:00</span>
+                  <span class="divider">/</span>
+                  <span id="duration">0:00</span>
+                </div>
+              </div>
+              <div class="controls-right">
+                <button id="fullscreen-toggle" class="control-btn" aria-label="Pantalla completa">
+                  ⛶
+                </button>
+              </div>
+            </div>
+            <input
+              id="progress-bar"
+              type="range"
+              min="0"
+              max="100"
+              value="0"
+              step="0.1"
+              aria-label="Progreso del video"
+              class="progress-bar"
+            />
+          </div>
+        </div>
       </div>
     </div>
 
@@ -189,6 +228,13 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
   <!-- Inicialización del reproductor -->
   <script client:load>
     const video = document.getElementById('video-player');
+    const playToggle = document.getElementById('play-toggle');
+    const muteToggle = document.getElementById('mute-toggle');
+    const volumeSlider = document.getElementById('volume-slider');
+    const progressBar = document.getElementById('progress-bar');
+    const currentTimeEl = document.getElementById('current-time');
+    const durationEl = document.getElementById('duration');
+    const fullscreenToggle = document.getElementById('fullscreen-toggle');
     const rawUrl = video.dataset.videoUrl;
     const userId = video.dataset.userId;
     const episodioId = video.dataset.episodioId;
@@ -227,6 +273,64 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
       } catch (error) {
         console.error('No se pudo normalizar la URL del video', error);
         return targetUrl;
+      }
+    };
+
+    const formatTime = (seconds) => {
+      if (!Number.isFinite(seconds)) return '0:00';
+      const minutes = Math.floor(seconds / 60);
+      const secs = Math.floor(seconds % 60)
+        .toString()
+        .padStart(2, '0');
+      return `${minutes}:${secs}`;
+    };
+
+    const togglePlay = () => {
+      if (video.paused) {
+        video.play();
+      } else {
+        video.pause();
+      }
+    };
+
+    const updatePlayIcon = () => {
+      playToggle.textContent = video.paused ? '▶' : '⏸';
+    };
+
+    const toggleMute = () => {
+      video.muted = !video.muted;
+      muteToggle.textContent = video.muted || video.volume === 0 ? '🔇' : '🔊';
+    };
+
+    const syncVolume = (value) => {
+      video.volume = value;
+      video.muted = value === 0;
+      muteToggle.textContent = video.muted ? '🔇' : '🔊';
+    };
+
+    const updateProgress = () => {
+      if (!video.duration) return;
+      const percent = (video.currentTime / video.duration) * 100;
+      progressBar.value = percent;
+      currentTimeEl.textContent = formatTime(video.currentTime);
+    };
+
+    const syncDuration = () => {
+      durationEl.textContent = formatTime(video.duration);
+    };
+
+    const seekTo = (percent) => {
+      if (!video.duration) return;
+      const time = (percent / 100) * video.duration;
+      video.currentTime = time;
+    };
+
+    const toggleFullscreen = () => {
+      const container = document.fullscreenElement ? document.fullscreenElement : document.querySelector('.player-shell');
+      if (!document.fullscreenElement) {
+        container?.requestFullscreen?.();
+      } else {
+        document.exitFullscreen?.();
       }
     };
 
@@ -390,11 +494,18 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
         }
       };
 
-      video.addEventListener('play', startProgressLoop);
-      video.addEventListener('pause', () => stopProgressLoop(true));
+      video.addEventListener('play', () => {
+        startProgressLoop();
+        updatePlayIcon();
+      });
+      video.addEventListener('pause', () => {
+        stopProgressLoop(true);
+        updatePlayIcon();
+      });
       video.addEventListener('ended', () => {
         stopProgressLoop(false);
         persistProgress(video.duration || video.currentTime || savedProgress, true);
+        updatePlayIcon();
       });
 
       window.addEventListener('beforeunload', () => {
@@ -402,9 +513,24 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
         persistProgress(video.currentTime || 0, video.ended);
       });
 
-      video.addEventListener('loadedmetadata', applySavedProgress, { once: true });
+      video.addEventListener('loadedmetadata', () => {
+        applySavedProgress();
+        syncDuration();
+      });
+      video.addEventListener('timeupdate', updateProgress);
+      video.addEventListener('click', togglePlay);
+
+      playToggle?.addEventListener('click', togglePlay);
+      muteToggle?.addEventListener('click', toggleMute);
+      volumeSlider?.addEventListener('input', (e) => syncVolume(Number(e.target.value)));
+      progressBar?.addEventListener('input', (e) => seekTo(Number(e.target.value)));
+      fullscreenToggle?.addEventListener('click', toggleFullscreen);
+
+      syncDuration();
+      updateProgress();
       initializePlayer();
       applySavedProgress();
+      updatePlayIcon();
     }
   </script>
 
@@ -413,15 +539,186 @@ const nextEp = index < todosEps.length - 1 ? todosEps[index + 1] : null;
       aspect-ratio: 16/9;
     }
 
-    .player-shell video::-webkit-media-controls-panel {
-      background: linear-gradient(180deg, rgba(15, 23, 42, 0.8) 0%, rgba(15, 23, 42, 0.9) 100%);
+    .player-shell video::-webkit-media-controls-enclosure {
+      display: none !important;
     }
 
-    .player-shell video::-webkit-media-controls-current-time-display,
-    .player-shell video::-webkit-media-controls-time-remaining-display {
+    .player-shell {
+      position: relative;
+      isolation: isolate;
+    }
+
+    .player-overlay {
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 20% 20%, rgba(139, 92, 246, 0.15), transparent 40%),
+        radial-gradient(circle at 80% 10%, rgba(59, 130, 246, 0.12), transparent 35%),
+        linear-gradient(180deg, rgba(0, 0, 0, 0) 40%, rgba(0, 0, 0, 0.55) 100%);
+      pointer-events: none;
+      mix-blend-mode: screen;
+      opacity: 0.8;
+    }
+
+    .player-ui {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 16px;
+      pointer-events: none;
+    }
+
+    .player-top {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      justify-content: flex-end;
+    }
+
+    .pill {
+      background: rgba(255, 255, 255, 0.1);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      backdrop-filter: blur(6px);
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 700;
       color: white;
-      font-weight: 600;
-      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    .player-bottom {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      background: linear-gradient(180deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.65));
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 10px 12px;
+      box-shadow: 0 15px 60px rgba(0, 0, 0, 0.4);
+      pointer-events: auto;
+    }
+
+    .player-controls {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .controls-left,
+    .controls-right {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .control-btn {
+      background: rgba(255, 255, 255, 0.12);
+      color: white;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 10px;
+      padding: 8px 10px;
+      cursor: pointer;
+      transition: transform 150ms ease, background 150ms ease, box-shadow 150ms ease;
+      box-shadow: 0 5px 20px rgba(0, 0, 0, 0.25);
+      font-size: 16px;
+    }
+
+    .control-btn:hover {
+      transform: translateY(-1px);
+      background: rgba(255, 255, 255, 0.18);
+    }
+
+    .control-btn:focus-visible {
+      outline: 2px solid rgba(168, 85, 247, 0.6);
+      outline-offset: 2px;
+    }
+
+    .time-display {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: #e5e7eb;
+      font-variant-numeric: tabular-nums;
+      font-size: 14px;
+      background: rgba(255, 255, 255, 0.06);
+      padding: 6px 10px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .divider {
+      color: rgba(229, 231, 235, 0.6);
+    }
+
+    .progress-bar {
+      appearance: none;
+      width: 100%;
+      height: 8px;
+      border-radius: 999px;
+      background: linear-gradient(90deg, rgba(168, 85, 247, 0.8), rgba(56, 189, 248, 0.85));
+      outline: none;
+      cursor: pointer;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .progress-bar::-webkit-slider-thumb {
+      appearance: none;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: white;
+      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+      border: 2px solid rgba(168, 85, 247, 0.8);
+      transition: transform 150ms ease;
+    }
+
+    .progress-bar::-webkit-slider-thumb:hover {
+      transform: scale(1.05);
+    }
+
+    .progress-bar::-moz-range-thumb {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: white;
+      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+      border: 2px solid rgba(168, 85, 247, 0.8);
+      transition: transform 150ms ease;
+    }
+
+    .volume-slider {
+      appearance: none;
+      width: 90px;
+      height: 6px;
+      border-radius: 999px;
+      background: linear-gradient(90deg, rgba(59, 130, 246, 0.8), rgba(168, 85, 247, 0.85));
+      outline: none;
+      cursor: pointer;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .volume-slider::-webkit-slider-thumb {
+      appearance: none;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: white;
+      box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+      border: 2px solid rgba(59, 130, 246, 0.8);
+    }
+
+    .volume-slider::-moz-range-thumb {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: white;
+      box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+      border: 2px solid rgba(59, 130, 246, 0.8);
     }
   </style>
 </Layout>


### PR DESCRIPTION
## Summary
- move the episode player higher on the page and restyle the shell with gradients and badges
- replace native video controls with custom play, volume, progress, and fullscreen UI elements
- remove hover tinting and hide default controls to keep the new player design visible

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959aae1daf48331bb6f7744e4866ed1)