### PR TITLE
Alinear carrusel 'Destacadas' a la izquierda y mejorar controles

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -290,7 +290,7 @@ const monthlyHighlights =
   )}
 
   <section class="px-4 space-y-10 pb-12">
-    <div class="mx-auto max-w-6xl flex flex-col gap-6" data-carousel="featured">
+    <div class="max-w-6xl mr-auto flex flex-col gap-6 items-start text-left" data-carousel="featured">
       <div class="flex flex-wrap items-center justify-between gap-4">
       <div>
         <p class="text-sm uppercase tracking-[0.25em] text-purple-200/70">Selección</p>
@@ -310,7 +310,7 @@ const monthlyHighlights =
       </div>
 
       <div
-        class="flex gap-6 overflow-x-auto pb-4 snap-x snap-mandatory scroll-smooth scrollbar-hide"
+        class="flex gap-8 overflow-x-auto pb-6 pt-2 snap-x snap-mandatory scroll-smooth scrollbar-hide"
         data-carousel-track
       >
         {monthlyHighlights.map(s => (
@@ -670,13 +670,13 @@ const monthlyHighlights =
       const styles = getComputedStyle(track);
       const parsedGap = parseFloat(styles.columnGap || styles.gap || '0');
       const gap = Number.isFinite(parsedGap) ? parsedGap : 0;
-      return firstCard.getBoundingClientRect().width + gap;
+      return Math.round(firstCard.getBoundingClientRect().width + gap);
     };
 
     const updateButtons = () => {
-      const maxScroll = track.scrollWidth - track.clientWidth - 2;
-      const atStart = track.scrollLeft <= 0;
-      const atEnd = track.scrollLeft >= maxScroll;
+      const maxScroll = track.scrollWidth - track.clientWidth;
+      const atStart = track.scrollLeft <= 1;
+      const atEnd = track.scrollLeft + track.clientWidth >= maxScroll - 1;
 
       prev?.toggleAttribute('disabled', atStart);
       next?.toggleAttribute('disabled', atEnd);
@@ -684,10 +684,12 @@ const monthlyHighlights =
 
     prev?.addEventListener('click', () => {
       track.scrollBy({ left: -getStep(), behavior: 'smooth' });
+      requestAnimationFrame(updateButtons);
     });
 
     next?.addEventListener('click', () => {
       track.scrollBy({ left: getStep(), behavior: 'smooth' });
+      requestAnimationFrame(updateButtons);
     });
 
     track.addEventListener('scroll', () => updateButtons());


### PR DESCRIPTION
### Motivation
- La sección de "Destacadas del mes" estaba centrada y las tarjetas quedaban muy pegadas, además las flechas/controles del carrusel no actualizaban bien su estado ni recorrían correctamente los elementos.

### Description
- Cambiado el contenedor del carrusel para alinearlo a la izquierda y forzar `text-left` usando `max-w-6xl mr-auto items-start text-left` en lugar de `mx-auto`.
- Aumentado el espaciado y paddings del track del carrusel modificando la clase a `flex gap-8 overflow-x-auto pb-6 pt-2` para separar las tarjetas.
- Ajustada la función `getStep` para usar `Math.round(...)` al calcular el paso de scroll y evitar desfases por subpíxeles.
- Afinado `updateButtons` para calcular `maxScroll` y los umbrales `atStart`/`atEnd` con comparaciones tolerantes y añadido `requestAnimationFrame(updateButtons)` tras los clicks de `prev`/`next` para actualizar el estado de los botones inmediatamente.

### Testing
- Levanté el servidor de desarrollo con `pnpm dev --host 0.0.0.0 --port 4321` y la aplicación respondió HTTP `200` (se registró un error de conexión a la base de datos en el log, pero la página se sirvió correctamente).
- Ejecuté un script de Playwright que navegó a la página principal y creó la captura `artifacts/index-featured-carousel.png`, la generación del screenshot se completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982d1644b988331b068fcc9d790092d)