### PR TITLE
Fix carousel initialization, favorites navigation, and subscription visibility

### DIFF
--- a/src/pages/favoritos.astro
+++ b/src/pages/favoritos.astro
@@ -61,9 +61,10 @@ const [favoritos] = await db.query<Favorito[]>(
       <div id="favorites-grid" class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {favoritos.map(fav => (
           <article
-            class="group relative overflow-hidden rounded-2xl border border-white/5 bg-slate-900/70 shadow-xl transition hover:-translate-y-1 hover:border-purple-500/50"
+            class="group relative cursor-pointer overflow-hidden rounded-2xl border border-white/5 bg-slate-900/70 shadow-xl transition hover:-translate-y-1 hover:border-purple-500/50"
             data-serie-card
             data-serie-id={fav.id}
+            data-serie-slug={fav.slug}
           >
             <div class="aspect-video overflow-hidden">
               <img src={fav.icon} alt={fav.titulo} class="h-full w-full object-cover transition duration-500 group-hover:scale-105" />
@@ -106,6 +107,16 @@ const [favoritos] = await db.query<Favorito[]>(
     grid.addEventListener('click', async (event) => {
       const target = event.target as HTMLElement;
       const button = target.closest('.remove-fav') as HTMLElement | null;
+      const card = target.closest('[data-serie-card]') as HTMLElement | null;
+      const isLink = Boolean(target.closest('a'));
+
+      if (card && !button && !isLink) {
+        const slug = card.dataset.serieSlug;
+        if (slug) {
+          window.location.href = `/serie/${slug}`;
+        }
+        return;
+      }
       if (!button) return;
 
       const serieId = button.dataset.serieId;

--- a/src/pages/header.astro
+++ b/src/pages/header.astro
@@ -17,7 +17,7 @@ import Layout from '../layouts/Layout.astro';
           <nav class="hidden md:flex space-x-6 font-medium">
             <a href="/directorio" class="text-white hover:text-purple-400">Directorio</a>
             <a href="/explorar" class="text-white hover:text-purple-400">Explorar</a>
-            <a href="/suscripciones" class="text-white hover:text-purple-400">Suscripciones</a>
+            <a href="/suscripciones" class="text-white hover:text-purple-400" data-subscription-link>Suscripciones</a>
           </nav>
         </div>
       <!-- DERECHA: Iconos, Perfil y Toggle Mobile -->
@@ -86,7 +86,7 @@ import Layout from '../layouts/Layout.astro';
     <div id="mobile-menu" class="hidden md:hidden mt-2 space-y-2 pb-4">
       <a href="/directorio" class="block px-4 py-2 text-white hover:bg-gray-800 rounded">Directorio</a>
       <a href="/explorar" class="block px-4 py-2 text-white hover:bg-gray-800 rounded">Explorar</a>
-      <a href="/suscripciones" class="block px-4 py-2 text-white hover:bg-gray-800 rounded">Suscripciones</a>
+      <a href="/suscripciones" class="block px-4 py-2 text-white hover:bg-gray-800 rounded" data-subscription-link>Suscripciones</a>
       <a href="/favoritos" class="block px-4 py-2 text-white hover:bg-gray-800 rounded">Favoritos</a>
       <div class="border-t border-gray-700 pt-2 flex items-center space-x-4 px-4">
         <a href="/buscar" aria-label="Buscar" class="text-white hover:text-purple-400">
@@ -112,6 +112,7 @@ import Layout from '../layouts/Layout.astro';
       const adminPanel = document.getElementById('admin-panel');
       const avatar = document.getElementById('user-avatar');
       const menuAvatar = document.getElementById('menu-avatar');
+      const subscriptionLinks = document.querySelectorAll('[data-subscription-link]');
 
       toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
       const toggleDropdown = (show?: boolean) => {
@@ -124,6 +125,10 @@ import Layout from '../layouts/Layout.astro';
       userBtn.addEventListener('click', e => { e.stopPropagation(); toggleDropdown(); });
       document.addEventListener('click', e => { if (!dropdown.contains(e.target) && !userBtn.contains(e.target)) toggleDropdown(false); });
 
+      const toggleSubscriptionLinks = (shouldHide) => {
+        subscriptionLinks.forEach(link => link.classList.toggle('hidden', shouldHide));
+      };
+
       fetch('/api/user').then(res => res.json()).then(user => {
         if (user.nickname) {
           avatar.src = user.imagen || '/avatar.svg';
@@ -131,6 +136,8 @@ import Layout from '../layouts/Layout.astro';
           loggedOut.classList.add('hidden');
           loggedIn.classList.remove('hidden');
           if (user.es_admin === 1) adminPanel.classList.remove('hidden');
+          const hasSubscription = Boolean(user.suscripcion && user.suscripcion !== 'Gratis');
+          toggleSubscriptionLinks(hasSubscription);
         }
       }).catch(() => {
         avatar.src = '/avatar.jpeg';

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -479,225 +479,227 @@ const monthlyHighlights =
 </style>
 
 <script>
-  const heroRoot = document.querySelector('[data-hero-root]');
-  const heroDataEl = document.getElementById('hero-data');
+  document.addEventListener('DOMContentLoaded', () => {
+    const heroRoot = document.querySelector('[data-hero-root]');
+    const heroDataEl = document.getElementById('hero-data');
 
-  let heroData = [];
+    let heroData = [];
 
-  try {
-    heroData = JSON.parse(heroDataEl?.textContent || '[]');
-  } catch (error) {
-    console.error('Error leyendo destacados del hero:', error);
-  }
+    try {
+      heroData = JSON.parse(heroDataEl?.textContent || '[]');
+    } catch (error) {
+      console.error('Error leyendo destacados del hero:', error);
+    }
 
-  if (heroRoot && heroData.length) {
-    const bannerEl = heroRoot.querySelector('[data-hero-banner]');
-    const titleEl = heroRoot.querySelector('[data-hero-title]');
-    const descriptionEl = heroRoot.querySelector('[data-hero-description]');
-    const genreEl = heroRoot.querySelector('[data-hero-genre]');
-    const seasonsEl = heroRoot.querySelector('[data-hero-seasons-text]');
-    const episodesEl = heroRoot.querySelector('[data-hero-episodes-text]');
-    const languageEl = heroRoot.querySelector('[data-hero-language]');
-    const languageText = heroRoot.querySelector('[data-hero-language-text]');
-    const ctaLink = heroRoot.querySelector('[data-hero-link]');
-    const thumbTrack = heroRoot.querySelector('[data-hero-thumbs]');
-    const thumbs = Array.from(heroRoot.querySelectorAll('[data-hero-thumb]'));
-    const prevHero = heroRoot.querySelector('[data-hero-prev]');
-    const nextHero = heroRoot.querySelector('[data-hero-next]');
+    if (heroRoot && heroData.length) {
+      const bannerEl = heroRoot.querySelector('[data-hero-banner]');
+      const titleEl = heroRoot.querySelector('[data-hero-title]');
+      const descriptionEl = heroRoot.querySelector('[data-hero-description]');
+      const genreEl = heroRoot.querySelector('[data-hero-genre]');
+      const seasonsEl = heroRoot.querySelector('[data-hero-seasons-text]');
+      const episodesEl = heroRoot.querySelector('[data-hero-episodes-text]');
+      const languageEl = heroRoot.querySelector('[data-hero-language]');
+      const languageText = heroRoot.querySelector('[data-hero-language-text]');
+      const ctaLink = heroRoot.querySelector('[data-hero-link]');
+      const thumbTrack = heroRoot.querySelector('[data-hero-thumbs]');
+      const thumbs = Array.from(heroRoot.querySelectorAll('[data-hero-thumb]'));
+      const prevHero = heroRoot.querySelector('[data-hero-prev]');
+      const nextHero = heroRoot.querySelector('[data-hero-next]');
 
-    let heroIndex = 0;
-    let heroTimer;
+      let heroIndex = 0;
+      let heroTimer;
 
-    const truncate = text => {
-      if (!text) return '';
-      return text.length > 200 ? `${text.slice(0, 200)}…` : text;
-    };
+      const truncate = text => {
+        if (!text) return '';
+        return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+      };
 
-    const highlightThumb = idx => {
+      const highlightThumb = idx => {
+        thumbs.forEach(thumb => {
+          const thumbIndex = Number(thumb.dataset.heroThumb);
+          const isActive = thumbIndex === idx;
+          thumb.classList.toggle('is-active', isActive);
+        });
+
+        const activeThumb = thumbs.find(thumb => Number(thumb.dataset.heroThumb) === idx);
+
+        if (activeThumb && thumbTrack) {
+          const thumbRect = activeThumb.getBoundingClientRect();
+          const trackRect = thumbTrack.getBoundingClientRect();
+
+          if (thumbRect.left < trackRect.left || thumbRect.right > trackRect.right) {
+            activeThumb.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+          }
+        }
+      };
+
+      const renderHero = idx => {
+        const hero = heroData[idx];
+        if (!hero) return;
+
+        heroIndex = idx;
+
+        if (bannerEl && hero.banner) {
+          bannerEl.src = hero.banner;
+          bannerEl.alt = hero.titulo || 'Serie destacada';
+        }
+
+        if (titleEl) {
+          titleEl.textContent = hero.titulo || 'Destacado';
+        }
+
+        if (descriptionEl) {
+          descriptionEl.textContent = truncate(hero.descripcion);
+        }
+
+        if (genreEl) {
+          genreEl.textContent = hero.genero || '';
+          genreEl.classList.toggle('hidden', !hero.genero);
+        }
+
+        if (seasonsEl) {
+          seasonsEl.textContent = `${hero.temporada_count ?? '–'} Temporadas`;
+        }
+
+        if (episodesEl) {
+          episodesEl.textContent = `${hero.episodio_count ?? '–'} Episodios`;
+        }
+
+        if (languageEl && languageText) {
+          const hasLanguage = Boolean(hero.idioma);
+          languageEl.classList.toggle('hidden', !hasLanguage);
+          languageText.textContent = hasLanguage ? `Idioma ${hero.idioma}` : '';
+        }
+
+        if (ctaLink && hero.slug) {
+          ctaLink.href = `/serie/${hero.slug}`;
+        }
+
+        highlightThumb(idx);
+      };
+
+      const goNext = () => {
+        renderHero((heroIndex + 1) % heroData.length);
+      };
+
+      const goPrev = () => {
+        renderHero((heroIndex - 1 + heroData.length) % heroData.length);
+      };
+
+      const stopAuto = () => {
+        if (heroTimer) {
+          clearInterval(heroTimer);
+          heroTimer = undefined;
+        }
+      };
+
+      const startAuto = () => {
+        stopAuto();
+        if (heroData.length <= 1) return;
+        heroTimer = setInterval(goNext, 7000);
+      };
+
+      prevHero?.addEventListener('click', () => {
+        goPrev();
+        startAuto();
+      });
+
+      nextHero?.addEventListener('click', () => {
+        goNext();
+        startAuto();
+      });
+
       thumbs.forEach(thumb => {
-        const thumbIndex = Number(thumb.dataset.heroThumb);
-        const isActive = thumbIndex === idx;
-        thumb.classList.toggle('is-active', isActive);
-      });
+        thumb.addEventListener('click', event => {
+          if (event.metaKey || event.ctrlKey || event.button !== 0) return;
 
-      const activeThumb = thumbs.find(thumb => Number(thumb.dataset.heroThumb) === idx);
+          event.preventDefault();
+          const thumbIndex = Number(thumb.dataset.heroThumb);
 
-      if (activeThumb && thumbTrack) {
-        const thumbRect = activeThumb.getBoundingClientRect();
-        const trackRect = thumbTrack.getBoundingClientRect();
-
-        if (thumbRect.left < trackRect.left || thumbRect.right > trackRect.right) {
-          activeThumb.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
-        }
-      }
-    };
-
-    const renderHero = idx => {
-      const hero = heroData[idx];
-      if (!hero) return;
-
-      heroIndex = idx;
-
-      if (bannerEl && hero.banner) {
-        bannerEl.src = hero.banner;
-        bannerEl.alt = hero.titulo || 'Serie destacada';
-      }
-
-      if (titleEl) {
-        titleEl.textContent = hero.titulo || 'Destacado';
-      }
-
-      if (descriptionEl) {
-        descriptionEl.textContent = truncate(hero.descripcion);
-      }
-
-      if (genreEl) {
-        genreEl.textContent = hero.genero || '';
-        genreEl.classList.toggle('hidden', !hero.genero);
-      }
-
-      if (seasonsEl) {
-        seasonsEl.textContent = `${hero.temporada_count ?? '–'} Temporadas`;
-      }
-
-      if (episodesEl) {
-        episodesEl.textContent = `${hero.episodio_count ?? '–'} Episodios`;
-      }
-
-      if (languageEl && languageText) {
-        const hasLanguage = Boolean(hero.idioma);
-        languageEl.classList.toggle('hidden', !hasLanguage);
-        languageText.textContent = hasLanguage ? `Idioma ${hero.idioma}` : '';
-      }
-
-      if (ctaLink && hero.slug) {
-        ctaLink.href = `/serie/${hero.slug}`;
-      }
-
-      highlightThumb(idx);
-    };
-
-    const goNext = () => {
-      renderHero((heroIndex + 1) % heroData.length);
-    };
-
-    const goPrev = () => {
-      renderHero((heroIndex - 1 + heroData.length) % heroData.length);
-    };
-
-    const stopAuto = () => {
-      if (heroTimer) {
-        clearInterval(heroTimer);
-        heroTimer = undefined;
-      }
-    };
-
-    const startAuto = () => {
-      stopAuto();
-      if (heroData.length <= 1) return;
-      heroTimer = setInterval(goNext, 7000);
-    };
-
-    prevHero?.addEventListener('click', () => {
-      goPrev();
-      startAuto();
-    });
-
-    nextHero?.addEventListener('click', () => {
-      goNext();
-      startAuto();
-    });
-
-    thumbs.forEach(thumb => {
-      thumb.addEventListener('click', event => {
-        if (event.metaKey || event.ctrlKey || event.button !== 0) return;
-
-        event.preventDefault();
-        const thumbIndex = Number(thumb.dataset.heroThumb);
-
-        if (!Number.isNaN(thumbIndex)) {
-          renderHero(thumbIndex);
-          startAuto();
-        }
-      });
-    });
-
-    heroRoot.addEventListener('mouseenter', stopAuto);
-    heroRoot.addEventListener('mouseleave', startAuto);
-
-    renderHero(0);
-    startAuto();
-  }
-
-  const carousels = document.querySelectorAll('[data-carousel]');
-
-  carousels.forEach(carousel => {
-    const track = carousel.querySelector('[data-carousel-track]');
-    const cards = Array.from(carousel.querySelectorAll('[data-carousel-card]'));
-
-    if (!track || !cards.length) return;
-
-    const prev = carousel.querySelector('[data-carousel-prev]');
-    const next = carousel.querySelector('[data-carousel-next]');
-
-    const getStep = () => {
-      const firstCard = cards[0];
-      if (!firstCard) return track.clientWidth;
-
-      const styles = getComputedStyle(track);
-      const parsedGap = parseFloat(styles.columnGap || styles.gap || '0');
-      const gap = Number.isFinite(parsedGap) ? parsedGap : 0;
-      return Math.round(firstCard.getBoundingClientRect().width + gap);
-    };
-
-    const updateButtons = () => {
-      const maxScroll = track.scrollWidth - track.clientWidth;
-      const atStart = track.scrollLeft <= 1;
-      const atEnd = track.scrollLeft + track.clientWidth >= maxScroll - 1;
-
-      prev?.toggleAttribute('disabled', atStart);
-      next?.toggleAttribute('disabled', atEnd);
-    };
-
-    prev?.addEventListener('click', () => {
-      track.scrollBy({ left: -getStep(), behavior: 'smooth' });
-      requestAnimationFrame(updateButtons);
-    });
-
-    next?.addEventListener('click', () => {
-      track.scrollBy({ left: getStep(), behavior: 'smooth' });
-      requestAnimationFrame(updateButtons);
-    });
-
-    track.addEventListener('scroll', () => updateButtons());
-    window.addEventListener('resize', () => updateButtons());
-
-    const observer = new IntersectionObserver(
-      entries => {
-        entries.forEach(entry => {
-          const card = entry.target;
-
-          if (entry.intersectionRatio > 0.75) {
-            card.classList.add('is-active');
-            card.classList.remove('is-near');
-          } else if (entry.intersectionRatio > 0.45) {
-            card.classList.add('is-near');
-            card.classList.remove('is-active');
-          } else {
-            card.classList.remove('is-active');
-            card.classList.remove('is-near');
+          if (!Number.isNaN(thumbIndex)) {
+            renderHero(thumbIndex);
+            startAuto();
           }
         });
-      },
-      {
-        root: track,
-        threshold: [0.45, 0.75],
-      }
-    );
+      });
 
-    cards.forEach(card => observer.observe(card));
+      heroRoot.addEventListener('mouseenter', stopAuto);
+      heroRoot.addEventListener('mouseleave', startAuto);
 
-    updateButtons();
+      renderHero(0);
+      startAuto();
+    }
+
+    const carousels = document.querySelectorAll('[data-carousel]');
+
+    carousels.forEach(carousel => {
+      const track = carousel.querySelector('[data-carousel-track]');
+      const cards = Array.from(carousel.querySelectorAll('[data-carousel-card]'));
+
+      if (!track || !cards.length) return;
+
+      const prev = carousel.querySelector('[data-carousel-prev]');
+      const next = carousel.querySelector('[data-carousel-next]');
+
+      const getStep = () => {
+        const firstCard = cards[0];
+        if (!firstCard) return track.clientWidth;
+
+        const styles = getComputedStyle(track);
+        const parsedGap = parseFloat(styles.columnGap || styles.gap || '0');
+        const gap = Number.isFinite(parsedGap) ? parsedGap : 0;
+        return Math.round(firstCard.getBoundingClientRect().width + gap);
+      };
+
+      const updateButtons = () => {
+        const maxScroll = track.scrollWidth - track.clientWidth;
+        const atStart = track.scrollLeft <= 1;
+        const atEnd = track.scrollLeft + track.clientWidth >= maxScroll - 1;
+
+        prev?.toggleAttribute('disabled', atStart);
+        next?.toggleAttribute('disabled', atEnd);
+      };
+
+      prev?.addEventListener('click', () => {
+        track.scrollBy({ left: -getStep(), behavior: 'smooth' });
+        requestAnimationFrame(updateButtons);
+      });
+
+      next?.addEventListener('click', () => {
+        track.scrollBy({ left: getStep(), behavior: 'smooth' });
+        requestAnimationFrame(updateButtons);
+      });
+
+      track.addEventListener('scroll', updateButtons, { passive: true });
+      window.addEventListener('resize', updateButtons);
+
+      const observer = new IntersectionObserver(
+        entries => {
+          entries.forEach(entry => {
+            const card = entry.target;
+
+            if (entry.intersectionRatio > 0.75) {
+              card.classList.add('is-active');
+              card.classList.remove('is-near');
+            } else if (entry.intersectionRatio > 0.45) {
+              card.classList.add('is-near');
+              card.classList.remove('is-active');
+            } else {
+              card.classList.remove('is-active');
+              card.classList.remove('is-near');
+            }
+          });
+        },
+        {
+          root: track,
+          threshold: [0.45, 0.75],
+        }
+      );
+
+      cards.forEach(card => observer.observe(card));
+
+      updateButtons();
+    });
   });
 
 </script>

--- a/src/pages/suscripciones.astro
+++ b/src/pages/suscripciones.astro
@@ -6,6 +6,19 @@ export const prerender = false;
 
 let suscripciones = [];
 const usuarioId = Astro.cookies.get('usuario_id')?.value;
+let userSubscription = 'Gratis';
+
+if (usuarioId) {
+  const [[userRow]] = await db.query<{ suscripcion: string }[]>(
+    `SELECT suscripcion FROM usuarios WHERE id = ? LIMIT 1`,
+    [usuarioId]
+  );
+  userSubscription = userRow?.suscripcion || 'Gratis';
+
+  if (userSubscription !== 'Gratis') {
+    throw redirect('/');
+  }
+}
 
 try {
   [suscripciones] = await db.query(`


### PR DESCRIPTION
### Motivation
- Improve reliability of the homepage hero/carousel initialization so arrows, highlighting and automatic rotation work after the DOM is ready.
- Make favorites cards navigate to the saved series when clicked while keeping the existing “Quitar” behavior intact.
- Prevent subscribed users from seeing or accessing the subscription purchase UI and redirect already-subscribed users away from the subscription page.

### Description
- Wrapped the homepage hero/carousel logic in a `DOMContentLoaded` handler and added minor event improvements (`passive` scroll listener) to ensure carousel arrows, scroll buttons and IntersectionObserver activation run after the DOM is available (`src/pages/index.astro`).
- Made favorite cards clickable by adding `cursor-pointer` and `data-serie-slug` attributes and updated the client script to navigate to the series page when a card (but not a link or remove button) is clicked (`src/pages/favoritos.astro`).
- Added `data-subscription-link` attributes to subscription links and toggled their visibility based on the logged-in user plan fetched from `/api/user` (`src/pages/header.astro`).
- On the subscriptions page, query the current user subscription and redirect to `/` if the user already has a non-`Gratis` plan to avoid showing the purchase UI (`src/pages/suscripciones.astro`).

### Testing
- Started the dev server with `pnpm dev --host 0.0.0.0 --port 4321` which launched successfully, although server logs showed a database connection error when loading home data (network DB unreachable) which did not prevent the server from responding.
- Captured a full-page screenshot of the home page with a Playwright script (artifact: `artifacts/home-carousel.png`) to verify carousel rendering and UI changes, and the screenshot run completed successfully.
- Changes were staged and committed with the message `Fix carousel, favorites navigation, and subscription visibility` and the repository state contains the four modified files listed above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982d5c90fe08331979872f856b53787)