### PR TITLE
Align home sections left and stabilize featured carousel

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -290,7 +290,7 @@ const monthlyHighlights =
   )}
 
   <section class="px-4 space-y-10 pb-12">
-    <div class="max-w-6xl mx-auto w-full flex flex-col gap-6 items-start text-left" data-carousel="featured">
+    <div class="max-w-6xl w-full flex flex-col gap-6 items-start text-left" data-carousel="featured">
       <div class="flex flex-wrap items-center justify-between gap-4">
         <div>
           <p class="text-sm uppercase tracking-[0.25em] text-purple-200/70">Selección</p>
@@ -336,7 +336,7 @@ const monthlyHighlights =
   </section>
 
   <section class="px-4 space-y-10">
-    <div class="mx-auto w-full max-w-6xl space-y-10 text-left">
+    <div class="w-full max-w-6xl space-y-10 text-left">
       <div class="flex items-center justify-between">
         <div>
           <p class="text-sm uppercase tracking-[0.25em] text-purple-200/70">Explora</p>
@@ -374,7 +374,7 @@ const monthlyHighlights =
   </section>
 
   <section class="px-4 space-y-10 mt-12">
-    <div class="mx-auto w-full max-w-6xl space-y-10 text-left">
+    <div class="w-full max-w-6xl space-y-10 text-left">
       <div class="flex items-center justify-between">
         <div>
           <p class="text-sm uppercase tracking-[0.25em] text-purple-200/70">Ranking</p>
@@ -404,7 +404,7 @@ const monthlyHighlights =
   </section>
 
   <section class="px-4 space-y-8 mt-12 pb-16">
-    <div class="mx-auto w-full max-w-6xl space-y-8 text-left">
+    <div class="w-full max-w-6xl space-y-8 text-left">
       <div class="flex items-center justify-between">
         <div>
           <p class="text-sm uppercase tracking-[0.25em] text-purple-200/70">Catálogo</p>
@@ -653,8 +653,10 @@ const monthlyHighlights =
         return Math.round(firstCard.getBoundingClientRect().width + gap);
       };
 
+      const getMaxScroll = () => Math.max(0, track.scrollWidth - track.clientWidth);
+
       const updateButtons = () => {
-        const maxScroll = track.scrollWidth - track.clientWidth;
+        const maxScroll = getMaxScroll();
         const atStart = track.scrollLeft <= 1;
         const atEnd = track.scrollLeft + track.clientWidth >= maxScroll - 1;
 
@@ -662,38 +664,29 @@ const monthlyHighlights =
         next?.toggleAttribute('disabled', atEnd);
       };
 
-      const getCurrentIndex = () => {
-        const scrollLeft = track.scrollLeft;
-        let nearestIndex = 0;
-        let nearestDistance = Number.POSITIVE_INFINITY;
+      const scrollByStep = direction => {
+        const maxScroll = getMaxScroll();
+        const step = getStep();
+        let target = track.scrollLeft + direction * step;
 
-        cards.forEach((card, index) => {
-          const distance = Math.abs(card.offsetLeft - scrollLeft);
-          if (distance < nearestDistance) {
-            nearestDistance = distance;
-            nearestIndex = index;
-          }
-        });
+        if (direction > 0 && track.scrollLeft >= maxScroll - 1) {
+          target = 0;
+        } else if (direction < 0 && track.scrollLeft <= 1) {
+          target = maxScroll;
+        } else {
+          target = Math.min(maxScroll, Math.max(0, target));
+        }
 
-        return nearestIndex;
-      };
-
-      const goToIndex = index => {
-        const target = cards[index];
-        if (!target) return;
-
-        track.scrollTo({ left: target.offsetLeft, behavior: 'smooth' });
+        track.scrollTo({ left: target, behavior: 'smooth' });
         requestAnimationFrame(updateButtons);
       };
 
       const goNext = () => {
-        const nextIndex = (getCurrentIndex() + 1) % cards.length;
-        goToIndex(nextIndex);
+        scrollByStep(1);
       };
 
       const goPrev = () => {
-        const prevIndex = (getCurrentIndex() - 1 + cards.length) % cards.length;
-        goToIndex(prevIndex);
+        scrollByStep(-1);
       };
 
       const stopAuto = () => {


### PR DESCRIPTION
### Motivation
- Move most homepage content blocks to the left to match the requested layout while keeping the "Continuar viendo" panel centered for visual balance.
- Fix unreliable carousel navigation which made the featured list difficult to control and caused wrap/scroll inconsistencies.

### Description
- Updated layout containers in `src/pages/index.astro` to remove `mx-auto` and related centering classes on major home sections so they are left-aligned while preserving the centered `Continuar viendo` panel.
- Replaced the carousel index-based navigation with a step-based scrolling approach by adding `getMaxScroll()` and `scrollByStep(direction)` and removed the `getCurrentIndex`/`goToIndex` logic to simplify behavior.
- Implemented wraparound behavior when advancing/rewinding the carousel and ensured `updateButtons()` uses `getMaxScroll()` for robust boundary checks.
- Adjusted `track.scrollTo` usage to scroll to numeric targets and kept `requestAnimationFrame(updateButtons)` to update control states after smooth scrolling.

### Testing
- Started the dev server with `pnpm dev -- --host 0.0.0.0 --port 4321` which reported `astro ready` and served on the expected port (success).
- Tried an automated screenshot with Playwright to validate layout and carousel, but the headless Chromium process crashed with a SIGSEGV and the Playwright run failed (failure).
- No unit or integration test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982db979cdc83319b7e2a2430eac1a6)