### PR TITLE
Center the Continue Watching section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -248,7 +248,7 @@ const monthlyHighlights =
 
   {usuarioId && continueWatchingNormalized.length > 0 && (
   <section class="px-4 pb-10">
-      <div class="w-full bg-gradient-to-r from-purple-900/50 via-black to-black/90 border border-purple-500/20 rounded-3xl p-6 shadow-2xl shadow-purple-500/30">
+      <div class="w-full max-w-6xl mx-auto bg-gradient-to-r from-purple-900/50 via-black to-black/90 border border-purple-500/20 rounded-3xl p-6 shadow-2xl shadow-purple-500/30">
         <div class="flex items-center justify-between mb-4">
           <div>
             <p class="text-xs uppercase tracking-[0.35em] text-purple-200/70">Retoma tu aventura</p>


### PR DESCRIPTION
### Motivation
- Constrain and center the “Continuar viendo” container so it appears centered on wide viewports instead of stretching full-width, matching the page layout intent.

### Description
- Add Tailwind constraints `max-w-6xl mx-auto` to the continue-watching container in `src/pages/index.astro` to limit its width and center it on the page.

### Testing
- Started the dev server with `npm run dev` (Astro started and served the site) and captured a Playwright screenshot of the page which succeeded, although the server logged a remote MySQL connection error (`ENETUNREACH`) while loading home data.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982dece2e0c8331831c95d7fdea3321)