### PR TITLE
Ajusta modo cine: ancho máximo y padding lateral responsive

### DIFF
--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -1228,9 +1228,9 @@ const canAccess = requiredLevel === 0 || (usuarioId && userLevel >= requiredLeve
     }
 
     .watch-section.cinema-mode {
-      max-width: 100%;
-      padding-left: 0;
-      padding-right: 0;
+      max-width: min(100%, 1680px);
+      padding-left: clamp(12px, 3vw, 40px);
+      padding-right: clamp(12px, 3vw, 40px);
     }
 
     .watch-section.cinema-mode .player-shell {


### PR DESCRIPTION
### Motivation
- Evitar que el modo cine se expanda a full-bleed y lograr una presentación más parecida al modo cine de YouTube manteniendo márgenes laterales.

### Description
- Modifiqué `.watch-section.cinema-mode` en `src/pages/serie/[slug]/[episodio].astro` para usar `max-width: min(100%, 1680px)` y `padding-left/right: clamp(12px, 3vw, 40px)`.

### Testing
- Ejecuté `pnpm build` y la compilación completó correctamente (hubo advertencias CSS pero sin fallo de build).
- Inicié `pnpm dev` para pruebas locales pero la validación completa de rutas dinámicas quedó limitada por un error de conexión a la base de datos (`ENETUNREACH`).
- Lancé un script de Playwright que generó capturas de la UI disponible, pero no pudo activar el toggle de modo cine porque no se accedió a una página de episodio con datos en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c7ebdc988331b993614d395dbd1c)