### PR TITLE
Ajusta el render de subtítulos para separar bloques <b> y <i>

### DIFF
--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -579,6 +579,21 @@ const canAccess = requiredLevel === 0 || (usuarioId && userLevel >= requiredLeve
       });
     };
 
+    const splitBAndICues = () => {
+      const subtitleTracks = Array.from(video.textTracks).filter((track) => track.kind === 'subtitles');
+      subtitleTracks.forEach((track) => {
+        const cues = track.cues ? Array.from(track.cues) : [];
+        cues.forEach((cue) => {
+          if (!(cue instanceof VTTCue) || typeof cue.text !== 'string') return;
+
+          const hasBoldAndItalic = /<b>[\s\S]*?<\/b>[\s\n\r]*<i>[\s\S]*?<\/i>/i.test(cue.text);
+          if (!hasBoldAndItalic) return;
+
+          cue.text = cue.text.replace(/<\/b>[\s\n\r]*<i>/gi, '</b>\n\n<i>');
+        });
+      });
+    };
+
     const toggleSubtitleSettingsPanel = () => {
       if (!(subtitleSettingsPanel instanceof HTMLElement)) return;
       const willShow = subtitleSettingsPanel.hidden;
@@ -761,6 +776,7 @@ const canAccess = requiredLevel === 0 || (usuarioId && userLevel >= requiredLeve
         track.default = true;
         video.appendChild(track);
         track.addEventListener('load', () => {
+          splitBAndICues();
           applySubtitleStyles();
           applySubtitlePosition();
           applySubtitleSelection(subtitleSettings.selectedTrack || '0');


### PR DESCRIPTION
### Motivation
- Separar visualmente textos en negrita (`<b>...</b>`) y cursiva (`<i>...</i>`) cuando aparecen en el mismo cue de WebVTT para que lo en negrita quede arriba y lo en cursiva abajo.

### Description
- Añade la función `splitBAndICues` que detecta cues con un bloque `<b>` seguido de `<i>` y reemplaza `</b>...<i>` por `</b>\n\n<i>` para forzar la separación en distintas líneas; la implementación está en `src/pages/serie/[slug]/[episodio].astro`.
- Ejecuta `splitBAndICues` en el handler `track.addEventListener('load', ...)` antes de aplicar estilos, posición y selección de subtítulos.

### Testing
- Ejecutado `pnpm build`, la compilación finalizó correctamente aunque mostró advertencias CSS menores (ok).
- Levantado el servidor con `pnpm dev --host 0.0.0.0 --port 4321` y la app respondió (ok).
- Ejecutado un script de Playwright para navegar a la app y capturar una captura de pantalla, y el script completó correctamente (ok).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984caa9ded48331a579c8d44d6c0472)