### PR TITLE
Fix overlapping subtitles by preserving cue line placement

### DIFF
--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -567,12 +567,38 @@ const canAccess = requiredLevel === 0 || (usuarioId && userLevel >= requiredLeve
       nextEpisodeCta.hidden = !shouldShow;
     };
 
+    const cueDefaults = new WeakMap();
+
+    const cueOverlapsAnother = (cue, cues) => {
+      return cues.some((otherCue) => {
+        if (otherCue === cue) return false;
+        return cue.startTime < otherCue.endTime && otherCue.startTime < cue.endTime;
+      });
+    };
+
     const applySubtitlePosition = () => {
       const subtitleTracks = Array.from(video.textTracks).filter((track) => track.kind === 'subtitles');
       subtitleTracks.forEach((track) => {
         const cues = track.cues ? Array.from(track.cues) : [];
         cues.forEach((cue) => {
           if (!('line' in cue)) return;
+
+          if (!cueDefaults.has(cue)) {
+            cueDefaults.set(cue, {
+              line: cue.line,
+              snapToLines: cue.snapToLines,
+            });
+          }
+
+          const defaults = cueDefaults.get(cue);
+          const hasFixedLineInSource = defaults?.line !== 'auto' && defaults?.line != null;
+
+          if (hasFixedLineInSource || cueOverlapsAnother(cue, cues)) {
+            cue.line = defaults.line;
+            cue.snapToLines = defaults.snapToLines;
+            return;
+          }
+
           cue.snapToLines = false;
           cue.line = subtitleSettings.position;
         });


### PR DESCRIPTION
### Motivation
- Subtitles were still stacking on top of each other when cues included explicit positioning or when two cues overlapped in time, so the height slider was incorrectly forcing `line` for every cue.

### Description
- Add a `WeakMap` named `cueDefaults` to preserve each cue's original `line` and `snapToLines` values.  
- Introduce `cueOverlapsAnother` helper to detect temporal overlap between cues.  
- Update `applySubtitlePosition` to restore original cue placement when a cue has an explicit source `line` or overlaps another cue, and only apply the `subtitleSettings.position` to movable, non-overlapping cues.

### Testing
- Ran `pnpm build` which completed successfully.  
- Started the dev server with `pnpm dev --host 0.0.0.0 --port 4321` which launched, but page rendering couldn't be fully validated due to an external MySQL connectivity error (`ENETUNREACH`).  
- Executed a headless Playwright capture that produced a screenshot, but the app page included the DB connectivity error in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ce3762708331ab3a0fdd1e84dbca)