### PR TITLE
Organiza uploads por carpeta de usuario

### DIFF
--- a/src/pages/api/profile/photo.ts
+++ b/src/pages/api/profile/photo.ts
@@ -1,7 +1,19 @@
 import type { APIRoute } from 'astro';
 import db from '../../../lib/db';
 import { writeFile } from 'fs/promises';
-import path from 'path';
+import { buildUserUploadPaths, ensureUserUploadDir } from '../../../utils/uploads';
+
+function getExtensionFromFile(file: File) {
+  const extFromName = file.name?.split('.').pop()?.toLowerCase();
+  if (extFromName && /^[a-z0-9]{2,5}$/.test(extFromName)) return extFromName;
+
+  if (file.type === 'image/jpeg') return 'jpg';
+  if (file.type === 'image/png') return 'png';
+  if (file.type === 'image/webp') return 'webp';
+  if (file.type === 'image/gif') return 'gif';
+
+  return 'png';
+}
 
 export const POST: APIRoute = async ({ request, cookies }) => {
   const usuarioId = cookies.get('usuario_id')?.value;
@@ -11,15 +23,19 @@ export const POST: APIRoute = async ({ request, cookies }) => {
   const file = form.get('photo') as File;
   if (!file) return new Response('No file', { status: 400 });
 
+  const extension = getExtensionFromFile(file);
+  const filename = `profile_${Date.now()}.${extension}`;
+
+  await ensureUserUploadDir(usuarioId, 'profile');
+  const { filePath, publicPath } = buildUserUploadPaths(usuarioId, 'profile', filename);
+
   const buffer = Buffer.from(await file.arrayBuffer());
-  const filename = `user_${usuarioId}_${Date.now()}.png`;
-  const filepath = path.resolve('./public/uploads', filename);
-  await writeFile(filepath, buffer);
+  await writeFile(filePath, buffer);
 
   await db.query(
     `UPDATE usuarios SET imagen = ? WHERE id = ?`,
-    [`/uploads/${filename}`, usuarioId]
+    [publicPath, usuarioId]
   );
 
-  return new Response(JSON.stringify({ message: 'Foto actualizada' }), { status: 200 });
+  return new Response(JSON.stringify({ message: 'Foto actualizada', path: publicPath }), { status: 200 });
 };

--- a/src/utils/uploads.ts
+++ b/src/utils/uploads.ts
@@ -1,0 +1,26 @@
+import path from 'path';
+import { mkdir } from 'fs/promises';
+
+function sanitizePathSegment(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+export function buildUserUploadPaths(userId: string, section: string, filename: string) {
+  const safeUserId = sanitizePathSegment(userId);
+  const safeSection = sanitizePathSegment(section);
+
+  const relativeDir = path.posix.join('uploads', `user_${safeUserId}`, safeSection);
+  const publicDir = path.resolve('public', relativeDir);
+  const publicPath = `/${path.posix.join(relativeDir, filename)}`;
+  const filePath = path.resolve(publicDir, filename);
+
+  return { publicDir, publicPath, filePath };
+}
+
+export async function ensureUserUploadDir(userId: string, section: string) {
+  const safeUserId = sanitizePathSegment(userId);
+  const safeSection = sanitizePathSegment(section);
+  const publicDir = path.resolve('public', 'uploads', `user_${safeUserId}`, safeSection);
+  await mkdir(publicDir, { recursive: true });
+  return publicDir;
+}


### PR DESCRIPTION
### Motivation
- Mantener `public/uploads` como base pero separar los archivos subidos por usuario y por sección (perfil, posts, chats) para evitar mezclar todo en una sola carpeta y facilitar gestión/limpieza.
- Proveer utilidades reutilizables para que futuros endpoints (chats, posts, etc.) puedan guardar en la misma estructura por usuario.

### Description
- Agrega el helper `src/utils/uploads.ts` que sanitiza segmentos, construye rutas (`filePath`, `publicPath`) y asegura la creación de carpetas con `mkdir(..., { recursive: true })`.
- Actualiza `POST /api/profile/photo` en `src/pages/api/profile/photo.ts` para detectar la extensión real del archivo (por nombre o MIME), generar un nombre `profile_<timestamp>.<ext>`, crear la carpeta del usuario con `ensureUserUploadDir` y guardar el archivo en `public/uploads/user_<id>/profile/...`.
- Cambia la actualización en la base de datos para guardar la `publicPath` generada en vez de la ruta plana anterior, y devuelve la `path` en la respuesta JSON.

### Testing
- Ejecutado `pnpm build` en el proyecto y la compilación finalizó correctamente con advertencias de CSS preexistentes, sin errores de build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdb11796ec833195e1c63022052744)