### PR TITLE
Add proper OG/Twitter metadata exposure in layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,22 +2,54 @@
 import Header from "../pages/header.astro";
 import Footer from "../pages/footer.astro";
 import "../styles/global.css";
+
+interface Props {
+	title?: string;
+	description?: string;
+	image?: string;
+	type?: "website" | "article";
+}
+
+const {
+	title = "ClawnVid",
+	description = "Explora anime en ClawnVid con series destacadas, estrenos y episodios en un solo lugar.",
+	image = "/avatar.jpeg",
+	type = "website",
+} = Astro.props;
+
+const canonicalUrl = Astro.url;
+const siteUrl = Astro.site ?? new URL(canonicalUrl.origin);
+const ogImageUrl = new URL(image, siteUrl).toString();
 ---
 <!doctype html>
-<html lang="en">
+<html lang="es">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
-		<title>ClawnVid</title>
+		<title>{title}</title>
+		<meta name="description" content={description} />
+		<link rel="canonical" href={canonicalUrl.toString()} />
 		<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+
+		<meta property="og:site_name" content="ClawnVid" />
+		<meta property="og:type" content={type} />
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		<meta property="og:url" content={canonicalUrl.toString()} />
+		<meta property="og:image" content={ogImageUrl} />
+
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={ogImageUrl} />
 	</head>
-        <body class="bg-black text-white">
-                <Header />
-                <main class="pt-16 md:pt-20">
-                        <slot />
-                </main>
-                <Footer />
-        </body>
+	<body class="bg-black text-white">
+		<Header />
+		<main class="pt-16 md:pt-20">
+			<slot />
+		</main>
+		<Footer />
+	</body>
 </html>
 
 <style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -113,7 +113,11 @@ const monthlyHighlights =
         : popular.slice(0, 8);
 ---
 
-<Layout>
+<Layout
+  title="ClawnVid | Mira anime online"
+  description="Descubre animes destacados, estrenos y continúa viendo tus episodios favoritos en ClawnVid."
+  image={initialHero?.banner || initialHero?.icon || "/avatar.jpeg"}
+>
   <section class="relative mt-6 px-4 pb-12" data-hero-root>
     <div class="relative overflow-hidden rounded-3xl bg-gradient-to-br from-purple-900/80 via-slate-900 to-black shadow-2xl ring-1 ring-purple-500/30">
         <div class="absolute inset-0">


### PR DESCRIPTION
### Motivation
- Provide consistent, page-configurable social and SEO metadata so previews on platforms (OG/Twitter) show correct title, description and image. 
- Normalize `og:image` to an absolute URL using the configured `Astro.site` (or request origin) to avoid broken/relative image links in social previews. 
- Ensure the homepage uses the hero content for social previews so shared links reflect the featured series.

### Description
- Added metadata props (`title`, `description`, `image`, `type`) and defaults to `src/layouts/Layout.astro` and switched document language to Spanish (`lang="es"`).
- Compute `canonicalUrl`, `siteUrl` (fallback to origin) and `ogImageUrl` (absolute image URL) using `Astro.url`/`Astro.site` and expose them in the head.
- Inserted standard Open Graph tags (`og:site_name`, `og:type`, `og:title`, `og:description`, `og:url`, `og:image`) and Twitter tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`) plus `meta description` and `link rel="canonical"`.
- Updated `src/pages/index.astro` to pass `title`, `description` and `image` (derived from `initialHero`) into the `Layout` so the homepage preview reflects the current hero.

### Testing
- Ran `pnpm build`, which completed successfully and produced server and client bundles.
- Build emitted pre-existing CSS minification warnings related to a Tailwind arbitrary class (`.aspect-[3/4]`), but these warnings did not block the build and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caedfe6e50833196724734df5576fd)