### PR TITLE
Agregar metadatos dinámicos Open Graph y Twitter para páginas de serie y episodio

### DIFF
--- a/src/pages/serie/[slug].astro
+++ b/src/pages/serie/[slug].astro
@@ -123,9 +123,20 @@ if (usuarioId) {
 }
 
 const userLevel = subscriptionRanks[userSubscription] ?? 0;
+const pageTitle = `${serie.titulo} | ClawnVid`;
+const pageDescription =
+  serie.descripcion?.trim() ||
+  `Descubre ${serie.titulo} en ClawnVid y explora todos sus episodios.`;
+const pageImage = serie.banner || '/avatar.jpeg';
 ---
 
-<Layout class="bg-[#050507] text-white">
+<Layout
+  title={pageTitle}
+  description={pageDescription}
+  image={pageImage}
+  type="article"
+  class="bg-[#050507] text-white"
+>
   <section class="relative isolate overflow-hidden bg-gradient-to-b from-black via-black/80 to-[#0b0b0f]">
     <div
       class="absolute inset-0 opacity-60"

--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -92,9 +92,20 @@ const requiredPlan = ep.suscripcion_requerida || 'Gratis';
 const requiredLevel = subscriptionRanks[requiredPlan] ?? 0;
 const userLevel = subscriptionRanks[userSubscription] ?? 0;
 const canAccess = requiredLevel === 0 || (usuarioId && userLevel >= requiredLevel);
+const pageTitle = `${serie.titulo} - ${ep.titulo} | ClawnVid`;
+const pageDescription =
+  serie.descripcion?.trim() ||
+  `Mira ${ep.titulo} de ${serie.titulo} en ClawnVid.`;
+const pageImage = ep.imagen_preview || serie.banner || '/avatar.jpeg';
 ---
 
-<Layout class="bg-black text-white">
+<Layout
+  title={pageTitle}
+  description={pageDescription}
+  image={pageImage}
+  type="article"
+  class="bg-black text-white"
+>
   <section id="watch-section" class="watch-section mt-12 max-w-6xl mx-auto px-6 sm:px-8 py-10 space-y-8">
     <div class="player-shell relative rounded-3xl overflow-hidden border border-white/10 shadow-2xl shadow-purple-500/30 bg-gradient-to-b from-purple-950/50 via-black to-black">
       <div class="aspect-video">


### PR DESCRIPTION
### Motivation
- Asegurar que las vistas compartidas muestren el `og:` y `twitter:` correctos para cada serie y episodio en lugar de usar metadatos genéricos de la página principal.

### Description
- Se añadieron `pageTitle`, `pageDescription` y `pageImage` calculados desde los datos (`serie` y `ep`) y se pasan a `Layout` como `title`, `description`, `image` y `type="article"` en las páginas dinámicas.
- Archivos modificados: `src/pages/serie/[slug].astro` y `src/pages/serie/[slug]/[episodio].astro`.
- La implementación reutiliza la lógica existente de `Layout` que ya convierte la `image` a una URL absoluta mediante `new URL(...)` para generar `og:image` y `twitter:image` correctos.

### Testing
- Ejecuté `pnpm build` y la compilación completó correctamente generando los artefactos de servidor y cliente.
- La compilación mostró advertencias de CSS relacionadas con `.aspect-[3/4]` pero finalizó con éxito (salida con código 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbebe13d8883319610bab53d44bc5f)