### PR TITLE
Fix CSS minifier warning for aspect-[3/4] selector

### DIFF
--- a/src/pages/buscar.astro
+++ b/src/pages/buscar.astro
@@ -457,5 +457,5 @@ if (q) {
 </Layout>
 
 <style>
-  .aspect-[3/4] { aspect-ratio: 3/4; }
+  .aspect-\[3\/4\] { aspect-ratio: 3/4; }
 </style>

--- a/src/pages/directorio.astro
+++ b/src/pages/directorio.astro
@@ -85,7 +85,7 @@ const series = Array.isArray(allSeries) ? allSeries : [];
 </Layout>
 
 <style>
-  .aspect-[3/4] {
+  .aspect-\[3\/4\] {
     aspect-ratio: 3/4;
   }
 </style>

--- a/src/pages/explorar.astro
+++ b/src/pages/explorar.astro
@@ -113,5 +113,5 @@ const lista = Array.isArray(series) ? series : [];
 </Layout>
 
 <style>
-  .aspect-[3/4] { aspect-ratio: 3/4; }
+  .aspect-\[3\/4\] { aspect-ratio: 3/4; }
 </style>


### PR DESCRIPTION
### Motivation
- The esbuild CSS minifier emits `Expected identifier but found "3"` for the unescaped custom selector `.aspect-[3/4]`, so the intent is to make the selector syntactically valid for the minifier and remove build warnings. 

### Description
- Replaced occurrences of `.aspect-[3/4]` with the escaped selector `.aspect-\[3\/4\]` in `src/pages/directorio.astro`, `src/pages/explorar.astro`, and `src/pages/buscar.astro`. 
- Preserved the original style rule `aspect-ratio: 3/4;` while only changing the selector syntax. 
- Changes are limited to page-level `<style>` blocks and do not alter runtime behavior or layout logic.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Confirmed the previous `Expected identifier but found "3"` css-syntax-error warnings no longer appear in the build output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf0950f90833196fb8e324c556837)