### PR TITLE
Fix proxy/video host normalization and avoid poster CORS failures

### DIFF
--- a/src/pages/api/proxy/video.ts
+++ b/src/pages/api/proxy/video.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 
-const ALLOWED_HOSTS = new Set(['videos.clawn.cat']);
+const ALLOWED_HOSTS = new Set(['videos.clawn.cat', 'videos.clawn.net']);
 
 const resolveTarget = (rawUrl: string) => {
   try {

--- a/src/pages/player/[episodio].html.ts
+++ b/src/pages/player/[episodio].html.ts
@@ -27,7 +27,10 @@ export const GET: APIRoute = async ({ params, request }) => {
 
   const normalizeBasePaths = (raw: string) => {
     const parsed = new URL(raw);
-    parsed.hostname = 'videos.clawn.cat';
+    const allowedVideoHosts = new Set(['videos.clawn.cat', 'videos.clawn.net']);
+    if (!allowedVideoHosts.has(parsed.hostname)) {
+      parsed.hostname = 'videos.clawn.net';
+    }
     parsed.protocol = 'https:';
 
     const host = `${parsed.protocol}//${parsed.hostname}`;

--- a/src/pages/serie/[slug]/[episodio].astro
+++ b/src/pages/serie/[slug]/[episodio].astro
@@ -97,6 +97,18 @@ const pageDescription =
   serie.descripcion?.trim() ||
   `Mira ${ep.titulo} de ${serie.titulo} en ClawnVid.`;
 const pageImage = ep.imagen_preview || serie.banner || '/avatar.jpeg';
+const allowedVideoHosts = new Set(['videos.clawn.cat', 'videos.clawn.net']);
+const proxifyMediaUrl = (targetUrl?: string | null) => {
+  if (!targetUrl) return '';
+  try {
+    const parsed = new URL(targetUrl);
+    if (!allowedVideoHosts.has(parsed.hostname)) return targetUrl;
+    return `/api/proxy/video?url=${encodeURIComponent(parsed.toString())}`;
+  } catch {
+    return targetUrl;
+  }
+};
+const posterUrl = proxifyMediaUrl(ep.imagen_preview);
 ---
 
 <Layout
@@ -113,7 +125,7 @@ const pageImage = ep.imagen_preview || serie.banner || '/avatar.jpeg';
           id="video-player"
           playsinline
           crossorigin="anonymous"
-          poster={ep.imagen_preview}
+          poster={posterUrl}
           data-video-url={canAccess ? ep.video_url : ''}
           data-user-id={usuarioId}
           data-episodio-id={episodio}
@@ -411,15 +423,16 @@ const pageImage = ep.imagen_preview || serie.banner || '/avatar.jpeg';
       }).catch((err) => console.error('No se pudo guardar el progreso', err));
     };
 
+    const allowedVideoHosts = new Set(['videos.clawn.cat', 'videos.clawn.net']);
     const normalizeHost = (targetUrl) => {
       try {
         const parsed = new URL(targetUrl);
 
-        // Fuerza el host correcto para evitar enlaces rotos o sin CORS
-        if (parsed.hostname !== 'videos.clawn.cat') {
-          parsed.hostname = 'videos.clawn.cat';
-          parsed.protocol = 'https:';
+        // Solo corrige si llega un dominio no permitido, manteniendo el host original válido.
+        if (!allowedVideoHosts.has(parsed.hostname)) {
+          parsed.hostname = 'videos.clawn.net';
         }
+        parsed.protocol = 'https:';
 
         return parsed.toString();
       } catch (error) {


### PR DESCRIPTION
### Motivation

- The player and proxy only allowed `videos.clawn.cat` and forced all video URLs to that host which caused 502s when assets were on `videos.clawn.net`.
- Video poster images requested directly from `videos.clawn.net` triggered CORS failures in browsers because they were not fetched via the app proxy.
- The goal is to accept both valid video hosts, avoid rewriting already-valid hosts, and ensure poster images are loaded same-origin to prevent CORS errors.

### Description

- Updated the proxy allowlist to accept both `videos.clawn.cat` and `videos.clawn.net` in `src/pages/api/proxy/video.ts` by adding the host to `ALLOWED_HOSTS`.
- In `src/pages/serie/[slug]/[episodio].astro` added `proxifyMediaUrl` and `allowedVideoHosts` and proxied the episode poster (`poster` attribute) when it comes from an approved video host so the browser loads it via `/api/proxy/video` instead of hitting the third party directly.
- Changed client-side host normalization in `src/pages/serie/[slug]/[episodio].astro` and `src/pages/player/[episodio].html.ts` to preserve either approved host (`.cat` or `.net`) and only rewrite unknown hosts to `videos.clawn.net`, removing the previous unconditional rewrite to `.cat`.

### Testing

- Ran a production build with `pnpm build` and the build completed successfully.
- No additional automated tests were added or run beyond the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe827b2fc8331aef2b8b9652640d2)