### PR TITLE
Fix mobile responsive overflow on homepage

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,7 +25,7 @@ const ogImageUrl = new URL(image, siteUrl).toString();
 <html lang="es">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<title>{title}</title>
 		<meta name="description" content={description} />
 		<link rel="canonical" href={canonicalUrl.toString()} />
@@ -43,7 +43,7 @@ const ogImageUrl = new URL(image, siteUrl).toString();
 		<meta name="twitter:description" content={description} />
 		<meta name="twitter:image" content={ogImageUrl} />
 	</head>
-	<body class="bg-black text-white">
+	<body class="bg-black text-white overflow-x-hidden">
 		<Header />
 		<main class="pt-16 md:pt-20">
 			<slot />

--- a/src/pages/header.astro
+++ b/src/pages/header.astro
@@ -1,7 +1,5 @@
 ---
-import Layout from '../layouts/Layout.astro';
 ---
-
 <header class="bg-black/60 supports-[backdrop-filter]:backdrop-blur-md fixed top-0 w-full z-50 border-b border-white/10 shadow-lg">
   <div class="w-full px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16 gap-2">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -314,13 +314,13 @@ const monthlyHighlights =
       </div>
 
       <div
-        class="flex flex-nowrap gap-8 overflow-x-auto pb-6 pt-2 snap-x snap-mandatory scroll-smooth scrollbar-hide"
+        class="flex flex-nowrap gap-4 sm:gap-8 overflow-x-auto pb-6 pt-2 snap-x snap-mandatory scroll-smooth scrollbar-hide"
         data-carousel-track
       >
         {monthlyHighlights.map(s => (
           <a
             href={`/serie/${s.slug}`}
-            class="featured-carousel-card relative group overflow-hidden rounded-2xl bg-gradient-to-b from-white/5 to-slate-900/60 border border-white/10 shadow-xl snap-start shrink-0 w-[260px] sm:w-[300px] lg:w-[320px] transition"
+            class="featured-carousel-card relative group overflow-hidden rounded-2xl bg-gradient-to-b from-white/5 to-slate-900/60 border border-white/10 shadow-xl snap-start shrink-0 w-[85vw] max-w-[320px] sm:w-[300px] lg:w-[320px] transition"
             data-carousel-card
           >
             <img src={s.icon} alt={s.titulo} class="w-full h-64 object-cover" />
@@ -479,6 +479,16 @@ const monthlyHighlights =
 
   [data-hero-thumb].is-active p:first-child {
     color: #fff;
+  }
+
+
+  @media (max-width: 640px) {
+    .featured-carousel-card,
+    .featured-carousel-card.is-near,
+    .featured-carousel-card.is-active {
+      transform: scale(1);
+      box-shadow: 0 12px 30px rgba(107, 33, 168, 0.2);
+    }
   }
 </style>
 


### PR DESCRIPTION
### Motivation
- Corregir el desbordamiento horizontal y el recorte visual en móviles causado por el carrusel de "Destacadas del mes" y por la configuración del layout para mejorar la experiencia responsive.

### Description
- Actualicé la meta `viewport` a `width=device-width, initial-scale=1, viewport-fit=cover` y añadí `overflow-x-hidden` al `<body>` para prevenir scroll horizontal en móviles, en `src/layouts/Layout.astro`.
- Reduje la separación del track del carrusel y cambié el ancho de las cards a `w-[85vw] max-w-[320px]` para que las tarjetas no empujen el layout en pantallas pequeñas, en `src/pages/index.astro`.
- Añadí una media query para desactivar los escalados agresivos de las tarjetas (`transform`/`box-shadow`) en pantallas <= 640px y así evitar clipping, en `src/pages/index.astro`.
- Eliminé un `import` no usado en `src/pages/header.astro` para limpiar el archivo y evitar problemas de frontmatter.

### Testing
- Ejecuté `pnpm build` y la compilación de Astro/Vite completó correctamente (build final: success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd64c142d08331a88dfb34c45630e1)