### PR TITLE
Improve homepage mobile responsiveness and grid spacing

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -118,8 +118,8 @@ const monthlyHighlights =
   description="Descubre animes destacados, estrenos y continúa viendo tus episodios favoritos en ClawnVid."
   image={initialHero?.banner || initialHero?.icon || "/avatar.jpeg"}
 >
-  <section class="relative mt-3 sm:mt-6 px-3 sm:px-4 pb-10 sm:pb-12" data-hero-root>
-    <div class="relative overflow-hidden rounded-3xl bg-gradient-to-br from-purple-900/80 via-slate-900 to-black shadow-2xl ring-1 ring-purple-500/30">
+  <section class="relative mt-3 sm:mt-6 px-3 sm:px-4 pb-10 sm:pb-12 max-w-screen-2xl mx-auto" data-hero-root>
+    <div class="relative overflow-hidden rounded-2xl sm:rounded-3xl bg-gradient-to-br from-purple-900/80 via-slate-900 to-black shadow-2xl ring-1 ring-purple-500/30">
         <div class="absolute inset-0">
           <div class="absolute inset-0 bg-white/5 opacity-10" aria-hidden="true" />
           <img
@@ -152,8 +152,8 @@ const monthlyHighlights =
         </div>
       )}
 
-      <div class="relative flex flex-col lg:flex-row gap-6 sm:gap-8 p-4 sm:p-6 lg:p-12 items-start">
-        <div class="flex-1 space-y-6 max-w-3xl">
+      <div class="relative flex flex-col lg:flex-row gap-5 sm:gap-8 p-4 sm:p-6 lg:p-12 items-start">
+        <div class="flex-1 space-y-5 sm:space-y-6 max-w-3xl w-full min-w-0">
           <div class="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.25em] text-purple-200/90">
             <span class="px-3 py-1 rounded-full bg-purple-600/70 backdrop-blur text-[11px]">Estreno destacado</span>
             {initialHero && (
@@ -163,10 +163,10 @@ const monthlyHighlights =
 
           <div class="space-y-3">
             <p class="text-sm text-purple-100/70">Bienvenido a tu hub de anime</p>
-            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-black text-white drop-shadow-xl leading-tight" data-hero-title>
+            <h1 class="text-2xl sm:text-4xl lg:text-5xl font-black text-white drop-shadow-xl leading-tight" data-hero-title>
               {initialHero?.titulo || 'Descubre tu próximo anime favorito'}
             </h1>
-            <p class="text-base text-gray-100/90 leading-relaxed max-w-2xl" data-hero-description>
+            <p class="text-[15px] sm:text-base text-gray-100/90 leading-relaxed max-w-2xl" data-hero-description>
               {initialHero
                 ? `${(initialHero.descripcion || '').slice(0, 200)}${initialHero.descripcion && initialHero.descripcion.length > 200 ? '…' : ''}`
                 : 'Explora estrenos, clásicos y recomendaciones seleccionadas con información clara de temporadas y episodios.'}
@@ -191,23 +191,23 @@ const monthlyHighlights =
             </span>
           </div>
 
-          <div class="flex flex-wrap gap-4">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 w-full sm:w-auto">
             {initialHero && (
               <a
                 href={`/serie/${initialHero.slug}`}
                 data-hero-link
-                class="px-6 py-3 rounded-xl bg-gradient-to-r from-purple-500 to-fuchsia-500 text-white font-semibold shadow-lg shadow-purple-600/40 hover:-translate-y-0.5 transition"
+                class="text-center px-6 py-3 rounded-xl bg-gradient-to-r from-purple-500 to-fuchsia-500 text-white font-semibold shadow-lg shadow-purple-600/40 hover:-translate-y-0.5 transition"
               >
                 Ver ahora
               </a>
             )}
-            <a href="/explorar" class="px-6 py-3 rounded-xl border border-white/15 text-white/90 hover:border-white/40 hover:text-white transition">
+            <a href="/explorar" class="text-center px-6 py-3 rounded-xl border border-white/15 text-white/90 hover:border-white/40 hover:text-white transition">
               Explorar catálogo
             </a>
           </div>
         </div>
 
-        <div class="w-full lg:w-[420px] space-y-4">
+        <div class="w-full lg:w-[420px] space-y-3 sm:space-y-4 min-w-0">
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div class="rounded-2xl bg-white/10 border border-white/10 p-4 text-white/90 backdrop-blur shadow-lg">
               <p class="text-xs text-purple-100/70">Series listadas</p>
@@ -227,12 +227,12 @@ const monthlyHighlights =
                 <span class="text-[11px] text-white/60">Selecciona para ver en grande</span>
               )}
             </div>
-            <div class="flex gap-3 overflow-x-auto pb-1 scrollbar-hide" data-hero-thumbs>
+            <div class="flex gap-3 overflow-x-auto pb-1 scrollbar-hide snap-x snap-mandatory" data-hero-thumbs>
               {heroThumbs.map((item, idx) => (
                 <a
                   href={`/serie/${item.slug}`}
                   data-hero-thumb={idx}
-                  class={`flex items-center gap-3 p-3 rounded-xl bg-black/30 border border-white/5 hover:border-purple-400/40 transition shrink-0 w-[250px] ${idx === 0 ? 'is-active' : ''}`}
+                  class={`flex items-center gap-3 p-3 rounded-xl bg-black/30 border border-white/5 hover:border-purple-400/40 transition shrink-0 w-[86vw] max-w-[250px] sm:w-[250px] snap-start ${idx === 0 ? 'is-active' : ''}`}
                 >
                   <img src={item.icon} alt={item.titulo} class="w-14 h-14 rounded-xl object-cover" />
                   <div class="space-y-1 text-left">
@@ -293,7 +293,7 @@ const monthlyHighlights =
     </section>
   )}
 
-  <section class="px-3 sm:px-4 space-y-10 pb-12">
+  <section class="px-3 sm:px-4 space-y-10 pb-12 max-w-screen-2xl mx-auto">
     <div class="w-full flex flex-col gap-6 items-start text-left" data-carousel="featured">
       <div class="flex flex-wrap items-start sm:items-center justify-between gap-4">
         <div>
@@ -339,7 +339,7 @@ const monthlyHighlights =
     </div>
   </section>
 
-  <section class="px-3 sm:px-4 space-y-10">
+  <section class="px-3 sm:px-4 space-y-10 max-w-screen-2xl mx-auto">
     <div class="w-full space-y-10 text-left">
       <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div>
@@ -349,7 +349,7 @@ const monthlyHighlights =
         </div>
         <a href="/explorar" class="text-sm text-purple-200 hover:text-white transition">Ver todo →</a>
       </div>
-      <div class="grid md:grid-cols-3 lg:grid-cols-4 gap-6">
+      <div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
         {recent.map(s => (
           <a href={`/serie/${s.slug}`} class="relative group overflow-hidden rounded-2xl bg-white/5 border border-white/10 shadow-xl backdrop-blur">
             {s.destacado_reciente && (
@@ -377,7 +377,7 @@ const monthlyHighlights =
     </div>
   </section>
 
-  <section class="px-3 sm:px-4 space-y-10 mt-12">
+  <section class="px-3 sm:px-4 space-y-10 mt-12 max-w-screen-2xl mx-auto">
     <div class="w-full space-y-10 text-left">
       <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div>
@@ -387,7 +387,7 @@ const monthlyHighlights =
         </div>
         <a href="/explorar?filtro=popular" class="text-sm text-purple-200 hover:text-white transition">Top 10 →</a>
       </div>
-      <div class="grid md:grid-cols-3 lg:grid-cols-4 gap-6">
+      <div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
         {popular.map(s => (
           <a href={`/serie/${s.slug}`} class="relative group overflow-hidden rounded-2xl bg-gradient-to-b from-slate-900/80 to-black border border-white/10 shadow-xl">
             <img src={s.icon} alt={s.titulo} class="w-full h-64 object-cover" />
@@ -407,7 +407,7 @@ const monthlyHighlights =
     </div>
   </section>
 
-  <section class="px-3 sm:px-4 space-y-8 mt-12 pb-16">
+  <section class="px-3 sm:px-4 space-y-8 mt-12 pb-16 max-w-screen-2xl mx-auto">
     <div class="w-full space-y-8 text-left">
       <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div>
@@ -417,7 +417,7 @@ const monthlyHighlights =
         </div>
         <a href="/directorio" class="text-sm text-purple-200 hover:text-white transition">Ver directorio →</a>
       </div>
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-6">
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 sm:gap-6">
         {allSeries.map(s => (
           <a href={`/serie/${s.slug}`} class="relative group overflow-hidden rounded-2xl bg-white/5 border border-white/10 shadow-lg transition hover:-translate-y-1">
             <img src={s.icon} alt={s.titulo} class="w-full h-56 object-cover" />


### PR DESCRIPTION
### Motivation
- The homepage layout was breaking on small screens with cramped CTAs, oversized hero text, and thumb scroller overflow, so the UI needed tuning for mobile readability and stable widths.

### Description
- Constrained main content with a centered `max-w-screen-2xl` wrapper and adjusted hero container corners for better small-screen rendering in `src/pages/index.astro`.
- Reduced hero title size on very small screens and adjusted description sizing and vertical spacing to avoid wrapping and overflow in the hero block.
- Converted hero CTAs to a responsive 1/2 column grid and ensured CTA buttons center-align on small devices to prevent overlap.
- Made the featured thumbnails horizontally snap and mobile-friendly by using `w-[86vw] max-w-[250px] sm:w-[250px] snap-start` and added `snap-x snap-mandatory` to the track, and tightened card grid breakpoints and gaps for "Nuevos Lanzamientos", "Popular" and "Directorio".

### Testing
- Ran `pnpm build` and the build completed successfully with no errors.
- Verified the site compiles and client assets were built during the automated build step (`astro build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd665d1d1c8331a3865fc59e9f2aa2)